### PR TITLE
fix(agents): refresh models store on registry delete + remove duplicate injection

### DIFF
--- a/front/backend/open_webui/main.py
+++ b/front/backend/open_webui/main.py
@@ -1114,38 +1114,8 @@ async def get_models(request: Request, user=Depends(get_verified_user)):
 
         models.append(model)
 
-    # Add A2A agent models if enabled
-    from open_webui.models.agents import Agents
-    enable_a2a = getattr(request.app.state.config, "ENABLE_A2A_AGENTS", True)
-    if enable_a2a:
-        try:
-            agents = Agents.get_agents()
-            for agent in agents:
-                model_id = f"agent:{agent.id}"
-                agent_model = {
-                    "id": model_id,
-                    "name": agent.name,
-                    "object": "model",
-                    "created": agent.created_at,
-                    "owned_by": "a2a-agent",
-                    "agent": {
-                        "id": agent.id,
-                        "description": agent.description,
-                        "endpoint": agent.endpoint or agent.url,
-                        "capabilities": agent.capabilities,
-                        "skills": agent.skills,
-                    },
-                    "info": {
-                        "meta": {
-                            "description": agent.description,
-                            "capabilities": agent.capabilities,
-                        }
-                    },
-                    "tags": [{"name": "agent"}, {"name": "a2a"}]
-                }
-                models.append(agent_model)
-        except Exception as e:
-            log.debug(f"Error loading A2A agents: {e}")
+    # A2A agents are already included by get_all_models() via utils/models.py.
+    # Do not add them again here — that would cause each agent to appear twice.
 
     model_order_list = request.app.state.config.MODEL_ORDER_LIST
     if model_order_list:

--- a/front/src/lib/components/workspace/Agents.svelte
+++ b/front/src/lib/components/workspace/Agents.svelte
@@ -142,6 +142,7 @@
 			await deleteRegistryAgent(localStorage.token as string, agent.id);
 			toast.success($i18n.t('Agent removed from registry'));
 			await refreshAgents();
+			models.set(await getModels(localStorage.token as string));
 		} catch {
 			toast.error($i18n.t('Failed to delete agent'));
 		}


### PR DESCRIPTION
## Summary

- **Dropdown not updating on delete:** `handleDelete` in `Agents.svelte` was missing a `models.set()` call after removing a registry agent, so the chat model selector never reflected the change until the user refreshed the page.
- **Duplicate agents in dropdown:** Agents were being injected into the models list in three separate places (`utils/models.py`, `routers/openai.py`, and `main.py`), causing each agent to appear 2–3× in the selector. Removed the redundant injection block in `main.py`.

## Changes

- `front/src/lib/components/workspace/Agents.svelte` — call `models.set(await getModels(...))` after a successful registry delete
- `front/backend/open_webui/main.py` — remove duplicate A2A agent injection block (agents are already added by `utils/models.py:get_all_models()`)

## Test plan

- [ ] Register an A2A agent via the registry UI — agent appears once in chat model selector
- [ ] Delete the agent from the registry — agent disappears from selector immediately (no page refresh required)
- [ ] Confirm no duplicate entries in the selector after registering multiple agents

## Related Issues

Closes #168 (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)