### PR TITLE
fix(registry): surface real error on POST /registry/ instead of generic 400

### DIFF
--- a/front/backend/open_webui/models/registry.py
+++ b/front/backend/open_webui/models/registry.py
@@ -1,11 +1,15 @@
+import logging
 import time
 from typing import Optional, List
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Column, String, Text, JSON, Boolean
 from sqlalchemy import or_, and_
+from sqlalchemy.exc import IntegrityError
 
 from open_webui.internal.db import Base, JSONField, get_db, engine
 from open_webui.utils.access_control import has_access
+
+log = logging.getLogger(__name__)
 
 ####################
 # Registry Agent DB Schema
@@ -130,8 +134,23 @@ class RegistryAgentsTable:
                 db.commit()
                 db.refresh(result)
                 return RegistryAgentModel.model_validate(result) if result else None
-            except Exception:
+            except IntegrityError as e:
+                db.rollback()
+                log.warning("registry insert failed (integrity): %s", e.orig)
                 return None
+            except Exception as e:
+                db.rollback()
+                log.exception("registry insert failed: %s", e)
+                return None
+
+    def get_agent_by_url(self, url: str) -> Optional[RegistryAgentModel]:
+        """Return the registry agent matching a given canonical URL, or None."""
+        try:
+            with get_db() as db:
+                agent = db.query(RegistryAgent).filter_by(url=url).first()
+                return RegistryAgentModel.model_validate(agent) if agent else None
+        except Exception:
+            return None
 
     def get_agent_by_id(self, id: str) -> Optional[RegistryAgentModel]:
         """Return a single registry agent by ID."""
@@ -203,7 +222,8 @@ class RegistryAgentsTable:
                 db.delete(agent)
                 db.commit()
                 return True
-        except Exception:
+        except Exception as e:
+            log.exception("registry delete failed for id=%s: %s", id, e)
             return False
 
 

--- a/front/backend/open_webui/routers/registry.py
+++ b/front/backend/open_webui/routers/registry.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 import requests
 from typing import Optional, List
@@ -5,6 +6,8 @@ from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
+
+log = logging.getLogger(__name__)
 
 from open_webui.models.registry import (
     RegistryAgentModel,
@@ -82,6 +85,12 @@ async def submit_registry_agent(
             "skills": agent_data.get("skills", []),
         }
 
+        if RegistryAgents.get_agent_by_url(url):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="An agent with this URL is already registered.",
+            )
+
         id = str(uuid.uuid4())
 
         agent = RegistryAgents.insert_new_agent(
@@ -99,11 +108,15 @@ async def submit_registry_agent(
 
         if agent:
             return agent
+
+        log.error("insert_new_agent returned None for url=%s user=%s", url, user.id)
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.DEFAULT(),
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to save agent to the registry. Check server logs for details.",
         )
 
+    except HTTPException:
+        raise
     except requests.exceptions.RequestException as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
## Summary

- **Root cause**: `insert_new_agent` was catching all exceptions silently (`except Exception: return None`), causing POST `/api/v1/registry/` to always return a generic `400 {"detail":"Something went wrong :/"}` regardless of the actual failure. Since all agents have been deleted there are no duplicate URL conflicts — this PR ensures Cloud Run logs will reveal the actual DB error.
- Add `IntegrityError`-specific handling with `db.rollback()` and `log.warning` in `insert_new_agent`
- Catch all other exceptions with `log.exception` so the stack trace appears in Cloud Run logs
- Add `get_agent_by_url()` for pre-insert duplicate detection, returning a clear **409 Conflict** instead of a silent failure
- Promote the unreachable-fallback error from 400 → **500** and log `url` + `user_id` so the failure is traceable
- Add `log.exception` to `delete_agent_by_id` for parity

## Test plan

- [ ] Deploy to dev and attempt to add an agent via `/workspace/agents`
- [ ] Check Cloud Run logs — the actual DB exception should now be visible
- [ ] Attempt to add the same agent twice — should return 409 with `"An agent with this URL is already registered."`
- [ ] Delete an agent and confirm re-registration succeeds without a 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)