### PR TITLE
feat(embed): popup-based OAuth for embed/iframe contexts

### DIFF
--- a/front/backend/open_webui/utils/oauth.py
+++ b/front/backend/open_webui/utils/oauth.py
@@ -11,7 +11,7 @@ from fastapi import (
     HTTPException,
     status,
 )
-from starlette.responses import RedirectResponse
+from starlette.responses import HTMLResponse, RedirectResponse
 
 from open_webui.models.auths import Auths
 from open_webui.models.users import Users
@@ -225,7 +225,17 @@ class OAuthManager:
         client = self.get_client(provider)
         if client is None:
             raise HTTPException(404)
-        return await client.authorize_redirect(request, redirect_uri)
+        redirect_response = await client.authorize_redirect(request, redirect_uri)
+        # Carry popup mode through the OAuth round-trip via a short-lived cookie
+        if request.query_params.get("popup") == "1":
+            redirect_response.set_cookie(
+                key="oauth_popup",
+                value="1",
+                httponly=True,
+                samesite="lax",
+                max_age=600,
+            )
+        return redirect_response
 
     async def handle_callback(self, request, provider, response):
         if provider not in OAUTH_PROVIDERS:
@@ -433,6 +443,26 @@ class OAuthManager:
                 samesite=WEBUI_AUTH_COOKIE_SAME_SITE,
                 secure=WEBUI_AUTH_COOKIE_SECURE,
             )
-        # Redirect back to the frontend with the JWT token
+        # Popup-initiated flow: close the window and pass the token back via postMessage
+        if request.cookies.get("oauth_popup") == "1":
+            response.delete_cookie("oauth_popup")
+            popup_html = f"""<!DOCTYPE html>
+<html>
+<head><title>Signing in...</title></head>
+<body>
+<script>
+  if (window.opener) {{
+    window.opener.postMessage(
+      {{ type: 'oauth_complete', token: '{jwt_token}' }},
+      window.location.origin
+    );
+  }}
+  window.close();
+</script>
+</body>
+</html>"""
+            return HTMLResponse(content=popup_html, headers=dict(response.headers))
+
+        # Standard redirect back to the frontend with the JWT token
         redirect_url = f"{request.base_url}auth#token={jwt_token}"
         return RedirectResponse(url=redirect_url, headers=response.headers)

--- a/front/src/routes/embed/+page.svelte
+++ b/front/src/routes/embed/+page.svelte
@@ -1,9 +1,11 @@
 <script>
-	import { onMount, tick } from 'svelte';
+	import { onMount, onDestroy, tick } from 'svelte';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 	import { toast } from 'svelte-sonner';
-    import { WEBUI_BASE_URL } from '$lib/constants';
+	import { WEBUI_BASE_URL } from '$lib/constants';
+	import { getBackendConfig } from '$lib/apis';
+	import { getSessionUser } from '$lib/apis/auths';
 
 	let agentId = '';
 	let agent = null;
@@ -14,6 +16,11 @@
 	let chatElement;
 	let showSelector = true;
 
+	// Auth state
+	let authenticated = false;
+	let authChecked = false;
+	let oauthProviders: Record<string, string> = {};
+
 	const scrollToBottom = async () => {
 		await tick();
 		if (chatElement) {
@@ -21,8 +28,32 @@
 		}
 	};
 
-	// Load agents list on mount
-	onMount(async () => {
+	const openOAuthPopup = (provider: string) => {
+		const url = `${WEBUI_BASE_URL}/oauth/${provider}/login?popup=1`;
+		window.open(url, 'oauth_popup', 'width=500,height=650,noopener=0');
+	};
+
+	const handlePopupMessage = async (event: MessageEvent) => {
+		// Only accept messages from same origin
+		if (event.origin !== window.location.origin) return;
+		if (!event.data || event.data.type !== 'oauth_complete') return;
+
+		const { token } = event.data;
+		if (!token) return;
+
+		try {
+			const sessionUser = await getSessionUser(token);
+			if (sessionUser) {
+				localStorage.token = token;
+				authenticated = true;
+				loadAgents();
+			}
+		} catch {
+			toast.error('Sign in failed. Please try again.');
+		}
+	};
+
+	const loadAgents = async () => {
 		try {
 			const res = await fetch('/api/embed/agents');
 			if (res.ok) {
@@ -34,6 +65,43 @@
 			console.error(e);
 			toast.error('Error loading agents');
 		}
+	};
+
+	// Load agents list on mount
+	onMount(async () => {
+		window.addEventListener('message', handlePopupMessage);
+
+		// Check for existing session
+		const token = localStorage.token;
+		if (token) {
+			try {
+				const sessionUser = await getSessionUser(token);
+				if (sessionUser) {
+					authenticated = true;
+				}
+			} catch {
+				// Token expired or invalid; fall through to sign-in UI
+				delete localStorage.token;
+			}
+		}
+
+		authChecked = true;
+
+		if (authenticated) {
+			await loadAgents();
+		} else {
+			// Fetch provider list so we can render sign-in buttons
+			try {
+				const backendConfig = await getBackendConfig();
+				oauthProviders = backendConfig?.oauth?.providers ?? {};
+			} catch {
+				// No providers available
+			}
+		}
+	});
+
+	onDestroy(() => {
+		window.removeEventListener('message', handlePopupMessage);
 	});
 
 	// Reactive logic to load agent when URL changes
@@ -170,7 +238,67 @@
     }
 </script>
 
-{#if showSelector}
+{#if !authChecked}
+	<!-- Waiting for auth check -->
+	<div class="flex h-screen items-center justify-center bg-gray-50 dark:bg-gray-900">
+		<div class="w-8 h-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin"></div>
+	</div>
+{:else if !authenticated}
+	<!-- Sign-in wall -->
+	<div class="flex flex-col h-screen items-center justify-center bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-gray-100 gap-6 px-8">
+		<img src="/favicon.png" alt="logo" class="w-12 h-12 rounded-full" />
+		<div class="text-center">
+			<h1 class="text-xl font-semibold">Sign in to continue</h1>
+			<p class="text-sm text-gray-500 dark:text-gray-400 mt-1">Authentication required to use this chat</p>
+		</div>
+		<div class="flex flex-col gap-2 w-full max-w-xs">
+			{#if oauthProviders.google}
+				<button
+					on:click={() => openOAuthPopup('google')}
+					class="flex justify-center items-center gap-3 w-full rounded-full py-2.5 text-sm font-medium bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 transition"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" class="size-5">
+						<path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/><path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/><path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/><path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/><path fill="none" d="M0 0h48v48H0z"/>
+					</svg>
+					Continue with Google
+				</button>
+			{/if}
+			{#if oauthProviders.microsoft}
+				<button
+					on:click={() => openOAuthPopup('microsoft')}
+					class="flex justify-center items-center gap-3 w-full rounded-full py-2.5 text-sm font-medium bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 transition"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 21 21" class="size-5">
+						<rect x="1" y="1" width="9" height="9" fill="#f25022"/><rect x="1" y="11" width="9" height="9" fill="#00a4ef"/><rect x="11" y="1" width="9" height="9" fill="#7fba00"/><rect x="11" y="11" width="9" height="9" fill="#ffb900"/>
+					</svg>
+					Continue with Microsoft
+				</button>
+			{/if}
+			{#if oauthProviders.github}
+				<button
+					on:click={() => openOAuthPopup('github')}
+					class="flex justify-center items-center gap-3 w-full rounded-full py-2.5 text-sm font-medium bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 transition"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="size-5">
+						<path fill="currentColor" d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.92 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57C20.565 21.795 24 17.31 24 12c0-6.63-5.37-12-12-12z"/>
+					</svg>
+					Continue with GitHub
+				</button>
+			{/if}
+			{#if oauthProviders.oidc}
+				<button
+					on:click={() => openOAuthPopup('oidc')}
+					class="flex justify-center items-center gap-3 w-full rounded-full py-2.5 text-sm font-medium bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 transition"
+				>
+					Continue with SSO
+				</button>
+			{/if}
+			{#if Object.keys(oauthProviders).length === 0}
+				<p class="text-sm text-center text-gray-400">No sign-in providers are configured.</p>
+			{/if}
+		</div>
+	</div>
+{:else if showSelector}
 	<!-- Agent Selection View -->
 	<div class="flex flex-col h-screen bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-gray-100">
 		<div class="px-6 py-4 border-b dark:border-gray-800 bg-white dark:bg-gray-950">


### PR DESCRIPTION
## Description

OAuth in the embed view (`/embed`) was failing due to cross-origin cookie rejection. When an iframe embeds the app, the browser blocks `SameSite=Lax` cookies on the OAuth callback redirect, silently dropping the session. This PR fixes that by switching to a popup-based OAuth flow that keeps authentication entirely in a first-party context — no cookie policy changes, no CSRF risk introduced.

Related issue: embed OAuth cross-origin cookie rejection.

## Changes Made

- [x] **`front/backend/open_webui/utils/oauth.py`** — `handle_login` sets a short-lived `oauth_popup` cookie (httponly, 10-min TTL) when `?popup=1` is passed in the query; `handle_callback` detects the cookie and returns a postMessage HTML page (`window.opener.postMessage + window.close()`) instead of a redirect
- [x] **`front/src/routes/embed/+page.svelte`** — auth check on mount via `getSessionUser`; sign-in wall with per-provider OAuth buttons (Google, Microsoft, GitHub, OIDC); `openOAuthPopup()` launches the provider at `/oauth/{provider}/login?popup=1`; `message` event listener validates `event.origin === window.location.origin` before accepting any token
- [x] No new dependencies, no cookie policy changes, no CSRF surface added

## Testing

1. **Sign-in wall** — open `/embed` without a token; wall renders with configured OAuth provider buttons
2. **Already-authenticated path** — sign in at `/auth`, navigate to `/embed`; agent selector loads directly
3. **postMessage simulation** — get a valid token from `/auth`, open `/embed`, clear `localStorage.token`, run in console: `window.postMessage({ type: 'oauth_complete', token: '<token>' }, window.location.origin)` — wall should disappear and agents load
4. **Full popup round-trip** — with an OAuth provider configured, click a provider button; popup opens to `/oauth/{provider}/login?popup=1`, completes auth, closes, embed authenticates

## Checklist

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes do not introduce any new warnings or errors.
- [x] Existing OAuth redirect flow is untouched (non-popup path unchanged).

## Screenshots (if applicable)

Sign-in wall renders in the embed when unauthenticated; popup opens on button click; popup closes and agent selector appears after successful auth.

## Additional Notes

- The `oauth_popup` cookie is httponly and `SameSite=lax` — it only needs to survive the round-trip within the same browser session, not cross-origin.
- The postMessage origin check (`event.origin !== window.location.origin`) prevents any cross-origin page from injecting a token.
- The existing redirect flow (`/auth#token=...`) is completely untouched for non-embed use.