### PR TITLE
fix(embed): add lang="ts" to script tag

### DIFF
--- a/front/src/routes/embed/+page.svelte
+++ b/front/src/routes/embed/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { onMount, onDestroy, tick } from 'svelte';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';


### PR DESCRIPTION
TypeScript type annotations require lang="ts"; the missing attribute caused the production Svelte build to fail with a parse error.