### PR TITLE
feat(trust-shields): agent trust tier system — Phase A (closes #159)

### DIFF
--- a/front/backend/dev.sh
+++ b/front/backend/dev.sh
@@ -1,2 +1,3 @@
 PORT="${PORT:-8080}"
-uvicorn open_webui.main:app --port $PORT --host 0.0.0.0 --forwarded-allow-ips "'*'" --reload
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHONPATH="${SCRIPT_DIR}" uvicorn open_webui.main:app --port $PORT --host 0.0.0.0 --forwarded-allow-ips "'*'" --reload

--- a/front/backend/open_webui/migrations/versions/b2c3d4e5f6a7_add_trust_tier_columns.py
+++ b/front/backend/open_webui/migrations/versions/b2c3d4e5f6a7_add_trust_tier_columns.py
@@ -1,0 +1,57 @@
+"""add trust tier columns to agent and registry_agent
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-23
+
+Implements the coarse access-gate model described in the OpenBeavs Chat Privacy
+Architecture §4 (Three-Tier Agent Access Model).
+
+New columns on `agent` and `registry_agent`:
+  - trust_tier    VARCHAR  'public' | 'authenticated' | 'privileged'
+                           Default 'public' so existing rows remain accessible.
+  - required_role VARCHAR  Optional OSU role hint (student/staff/faculty).
+                           Stored now, enforced once OSU OIDC lands (#141).
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "b2c3d4e5f6a7"
+down_revision = "a1b2c3d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("agent", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "trust_tier",
+                sa.String(),
+                nullable=False,
+                server_default="public",
+            )
+        )
+        batch_op.add_column(sa.Column("required_role", sa.String(), nullable=True))
+
+    with op.batch_alter_table("registry_agent", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "trust_tier",
+                sa.String(),
+                nullable=False,
+                server_default="public",
+            )
+        )
+        batch_op.add_column(sa.Column("required_role", sa.String(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("registry_agent", schema=None) as batch_op:
+        batch_op.drop_column("required_role")
+        batch_op.drop_column("trust_tier")
+
+    with op.batch_alter_table("agent", schema=None) as batch_op:
+        batch_op.drop_column("required_role")
+        batch_op.drop_column("trust_tier")

--- a/front/backend/open_webui/models/agents.py
+++ b/front/backend/open_webui/models/agents.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Optional, List
+from typing import Literal, Optional, List
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Column, String, Text, Boolean, text
 from sqlalchemy.exc import IntegrityError
@@ -75,7 +75,7 @@ class AgentModel(BaseModel):
     model: Optional[str] = None
     deployment_mode: Optional[str] = None
     deployment_status: Optional[str] = None
-    trust_tier: str = "public"
+    trust_tier: Literal["public", "authenticated", "privileged"] = "public"
     required_role: Optional[str] = None
     is_active: bool = True
     created_at: int
@@ -97,7 +97,7 @@ class AgentResponse(BaseModel):
     url: Optional[str] = None
     capabilities: Optional[dict] = None
     skills: Optional[List[dict]] = None
-    trust_tier: str = "public"
+    trust_tier: Literal["public", "authenticated", "privileged"] = "public"
     required_role: Optional[str] = None
     is_active: bool = True
 
@@ -108,7 +108,7 @@ class RegisterAgentForm(BaseModel):
     endpoint: Optional[str] = None
     input_schema: Optional[dict] = None
     output_schema: Optional[dict] = None
-    trust_tier: str = "public"
+    trust_tier: Literal["public", "authenticated", "privileged"] = "public"
     required_role: Optional[str] = None
 
 
@@ -123,7 +123,7 @@ class AgentUpdateForm(BaseModel):
     endpoint: Optional[str] = None
     url: Optional[str] = None
     is_active: Optional[bool] = None
-    trust_tier: Optional[str] = None
+    trust_tier: Optional[Literal["public", "authenticated", "privileged"]] = None
     required_role: Optional[str] = None
 
 
@@ -136,7 +136,7 @@ class DeployAgentForm(BaseModel):
     profile_image_url: Optional[str] = None
     publish_to_registry: bool = True
     deploy_to_cloud_run: bool = False
-    trust_tier: str = "public"
+    trust_tier: Literal["public", "authenticated", "privileged"] = "public"
     required_role: Optional[str] = None
 
     model_config = ConfigDict(protected_namespaces=())

--- a/front/backend/open_webui/models/agents.py
+++ b/front/backend/open_webui/models/agents.py
@@ -2,7 +2,7 @@ import logging
 import time
 from typing import Optional, List
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import BigInteger, Column, String, Text, Boolean
+from sqlalchemy import BigInteger, Column, String, Text, Boolean, text
 from sqlalchemy.exc import IntegrityError
 
 from open_webui.internal.db import Base, JSONField, get_db, engine
@@ -42,6 +42,11 @@ class Agent(Base):
     deployment_mode = Column(String, nullable=True)
     deployment_status = Column(String, nullable=True)
 
+    # Trust tier — coarse access gate (public / authenticated / privileged)
+    # TODO(#141/#143): replace role→tier mapping with real OSU OIDC scope claims
+    trust_tier = Column(String, nullable=False, server_default=text("'public'"))
+    required_role = Column(String, nullable=True)  # stored, not yet enforced (#141)
+
     # Metadata
     is_active = Column(Boolean, default=True)
     created_at = Column(BigInteger)
@@ -70,6 +75,8 @@ class AgentModel(BaseModel):
     model: Optional[str] = None
     deployment_mode: Optional[str] = None
     deployment_status: Optional[str] = None
+    trust_tier: str = "public"
+    required_role: Optional[str] = None
     is_active: bool = True
     created_at: int
     updated_at: int
@@ -90,6 +97,8 @@ class AgentResponse(BaseModel):
     url: Optional[str] = None
     capabilities: Optional[dict] = None
     skills: Optional[List[dict]] = None
+    trust_tier: str = "public"
+    required_role: Optional[str] = None
     is_active: bool = True
 
 
@@ -99,6 +108,8 @@ class RegisterAgentForm(BaseModel):
     endpoint: Optional[str] = None
     input_schema: Optional[dict] = None
     output_schema: Optional[dict] = None
+    trust_tier: str = "public"
+    required_role: Optional[str] = None
 
 
 class RegisterAgentByUrlForm(BaseModel):
@@ -112,6 +123,8 @@ class AgentUpdateForm(BaseModel):
     endpoint: Optional[str] = None
     url: Optional[str] = None
     is_active: Optional[bool] = None
+    trust_tier: Optional[str] = None
+    required_role: Optional[str] = None
 
 
 class DeployAgentForm(BaseModel):
@@ -123,6 +136,8 @@ class DeployAgentForm(BaseModel):
     profile_image_url: Optional[str] = None
     publish_to_registry: bool = True
     deploy_to_cloud_run: bool = False
+    trust_tier: str = "public"
+    required_role: Optional[str] = None
 
     model_config = ConfigDict(protected_namespaces=())
 
@@ -156,6 +171,8 @@ class AgentsTable:
         model: Optional[str] = None,
         deployment_mode: Optional[str] = None,
         deployment_status: Optional[str] = None,
+        trust_tier: str = "public",
+        required_role: Optional[str] = None,
         user_id: Optional[str] = None,
     ) -> Optional[AgentModel]:
         with get_db() as db:
@@ -179,6 +196,8 @@ class AgentsTable:
                     "model": model,
                     "deployment_mode": deployment_mode,
                     "deployment_status": deployment_status,
+                    "trust_tier": trust_tier,
+                    "required_role": required_role,
                     "is_active": True,
                     "created_at": int(time.time()),
                     "updated_at": int(time.time()),

--- a/front/backend/open_webui/models/agents.py
+++ b/front/backend/open_webui/models/agents.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from typing import Literal, Optional, List
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 from sqlalchemy import BigInteger, Column, String, Text, Boolean, text
 from sqlalchemy.exc import IntegrityError
 
@@ -111,6 +111,16 @@ class RegisterAgentForm(BaseModel):
     trust_tier: Literal["public", "authenticated", "privileged"] = "public"
     required_role: Optional[str] = None
 
+    @model_validator(mode="after")
+    def _validate_tier_role_pair(self) -> "RegisterAgentForm":
+        if self.trust_tier == "public":
+            self.required_role = None
+        elif self.trust_tier == "privileged" and not self.required_role:
+            raise ValueError(
+                "required_role must be set when trust_tier is 'privileged'"
+            )
+        return self
+
 
 class RegisterAgentByUrlForm(BaseModel):
     agent_url: str
@@ -140,6 +150,16 @@ class DeployAgentForm(BaseModel):
     required_role: Optional[str] = None
 
     model_config = ConfigDict(protected_namespaces=())
+
+    @model_validator(mode="after")
+    def _validate_tier_role_pair(self) -> "DeployAgentForm":
+        if self.trust_tier == "public":
+            self.required_role = None
+        elif self.trust_tier == "privileged" and not self.required_role:
+            raise ValueError(
+                "required_role must be set when trust_tier is 'privileged'"
+            )
+        return self
 
 
 ####################

--- a/front/backend/open_webui/models/registry.py
+++ b/front/backend/open_webui/models/registry.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+import logging
 from typing import Optional, List
 from pydantic import BaseModel, ConfigDict, field_validator
 from sqlalchemy import BigInteger, Column, String, Text, JSON, Boolean, text

--- a/front/backend/open_webui/models/registry.py
+++ b/front/backend/open_webui/models/registry.py
@@ -3,7 +3,7 @@ import logging
 import time
 from typing import Optional, List
 from pydantic import BaseModel, ConfigDict, field_validator
-from sqlalchemy import BigInteger, Column, String, Text, Boolean
+from sqlalchemy import BigInteger, Column, String, Text, JSON, Boolean, text
 from sqlalchemy import or_, and_
 from sqlalchemy.exc import IntegrityError
 
@@ -45,6 +45,11 @@ class RegistryAgent(Base):
     is_featured = Column(Boolean, default=False, nullable=False)
     # Only admins may set this. Featured agents appear in the dedicated showcase section.
 
+    # Trust tier — coarse access gate (public / authenticated / privileged)
+    # TODO(#141/#143): replace role→tier mapping with real OSU OIDC scope claims
+    trust_tier = Column(String, nullable=False, server_default=text("'public'"))
+    required_role = Column(String, nullable=True)  # stored, not yet enforced (#141)
+
     created_at = Column(BigInteger)
     updated_at = Column(BigInteger)
 
@@ -61,6 +66,8 @@ class RegistryAgentModel(BaseModel):
     access_control: Optional[dict] = None
     card_url: Optional[str] = None
     is_featured: bool = False
+    trust_tier: str = "public"
+    required_role: Optional[str] = None
     created_at: int
     updated_at: int
 
@@ -88,6 +95,8 @@ class SubmitRegistryAgentForm(BaseModel):
     access_control: Optional[dict] = None
     foundational_model: Optional[str] = None
     image_url: Optional[str] = None
+    trust_tier: str = "public"
+    required_role: Optional[str] = None
 
 
 class UpdateRegistryAgentForm(BaseModel):
@@ -96,6 +105,8 @@ class UpdateRegistryAgentForm(BaseModel):
     description: Optional[str] = None
     image_url: Optional[str] = None
     is_featured: Optional[bool] = None  # admin-only field; enforced in the router
+    trust_tier: Optional[str] = None
+    required_role: Optional[str] = None
 
 
 ####################
@@ -119,6 +130,8 @@ class RegistryAgentsTable:
         tools: Optional[dict] = None,
         access_control: Optional[dict] = None,
         card_url: Optional[str] = None,
+        trust_tier: str = "public",
+        required_role: Optional[str] = None,
     ) -> Optional[RegistryAgentModel]:
         """Insert a new agent into the registry."""
         with get_db() as db:
@@ -135,6 +148,8 @@ class RegistryAgentsTable:
                     "access_control": access_control,
                     "card_url": card_url,
                     "is_featured": False,
+                    "trust_tier": trust_tier,
+                    "required_role": required_role,
                     "created_at": int(time.time()),
                     "updated_at": int(time.time()),
                 }

--- a/front/backend/open_webui/models/registry.py
+++ b/front/backend/open_webui/models/registry.py
@@ -2,7 +2,7 @@ import json
 import logging
 import time
 import logging
-from typing import Optional, List
+from typing import Literal, Optional, List
 from pydantic import BaseModel, ConfigDict, field_validator
 from sqlalchemy import BigInteger, Column, String, Text, JSON, Boolean, text
 from sqlalchemy import or_, and_
@@ -67,7 +67,7 @@ class RegistryAgentModel(BaseModel):
     access_control: Optional[dict] = None
     card_url: Optional[str] = None
     is_featured: bool = False
-    trust_tier: str = "public"
+    trust_tier: Literal["public", "authenticated", "privileged"] = "public"
     required_role: Optional[str] = None
     created_at: int
     updated_at: int
@@ -96,7 +96,7 @@ class SubmitRegistryAgentForm(BaseModel):
     access_control: Optional[dict] = None
     foundational_model: Optional[str] = None
     image_url: Optional[str] = None
-    trust_tier: str = "public"
+    trust_tier: Literal["public", "authenticated", "privileged"] = "public"
     required_role: Optional[str] = None
 
 
@@ -106,7 +106,7 @@ class UpdateRegistryAgentForm(BaseModel):
     description: Optional[str] = None
     image_url: Optional[str] = None
     is_featured: Optional[bool] = None  # admin-only field; enforced in the router
-    trust_tier: Optional[str] = None
+    trust_tier: Optional[Literal["public", "authenticated", "privileged"]] = None
     required_role: Optional[str] = None
 
 

--- a/front/backend/open_webui/routers/agents.py
+++ b/front/backend/open_webui/routers/agents.py
@@ -86,23 +86,32 @@ def _enforce_tier(
     user_scope = _get_user_scope(user, elevated_until)
     available = _TIER_ORDER.get(user_scope, 0)
 
-    if available >= required:
-        return
+    if available < required:
+        # Distinguish "you need to log in" from "you need step-up MFA"
+        code = "tier_required" if user_scope == "public" else "step_up_required"
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": code,
+                "required_tier": agent.trust_tier,
+                "required_role": agent.required_role,
+            },
+        )
 
-    # Distinguish "you need to log in" from "you need step-up MFA"
-    if user_scope == "public":
-        code = "tier_required"
-    else:
-        code = "step_up_required"
-
-    raise HTTPException(
-        status_code=status.HTTP_403_FORBIDDEN,
-        detail={
-            "code": code,
-            "required_tier": agent.trust_tier,
-            "required_role": agent.required_role,
-        },
-    )
+    # Tier passed — check OSU role restriction if set (admin bypasses).
+    # user.osu_role is populated after #141 (OSU OIDC) lands; until then
+    # getattr returns None which correctly blocks role-restricted agents.
+    if agent.required_role and user is not None and getattr(user, "role", None) != "admin":
+        user_osu_role = getattr(user, "osu_role", None)
+        if user_osu_role != agent.required_role:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "code": "role_required",
+                    "required_tier": agent.trust_tier,
+                    "required_role": agent.required_role,
+                },
+            )
 
 ############################
 # JSON-RPC Message Models

--- a/front/backend/open_webui/routers/agents.py
+++ b/front/backend/open_webui/routers/agents.py
@@ -23,6 +23,51 @@ from open_webui.utils.a2a_runtime import PROVIDER_DEFAULTS, run_agent_turn
 
 router = APIRouter()
 
+# Tier ordering: higher index = higher privilege
+_TIER_ORDER = {"public": 0, "authenticated": 1, "privileged": 2}
+
+
+def _get_user_scope(user) -> str:
+    """Map the existing Open WebUI role to a trust tier.
+
+    TODO(#141/#143): Replace this with real OSU OIDC scope claims once the
+    identity provider integration in #141 lands.  For now we use the platform
+    role as a proxy:
+      admin   → privileged
+      user    → authenticated
+      pending → public
+    """
+    if user.role == "admin":
+        return "privileged"
+    if user.role == "user":
+        return "authenticated"
+    return "public"
+
+
+def _enforce_tier(agent: AgentModel, user) -> None:
+    """Raise a structured 403 if the user's scope is below the agent's tier."""
+    required = _TIER_ORDER.get(agent.trust_tier or "public", 0)
+    user_scope = _get_user_scope(user)
+    available = _TIER_ORDER.get(user_scope, 0)
+
+    if available >= required:
+        return
+
+    # Distinguish "you need to log in" from "you need step-up MFA"
+    if user_scope == "public":
+        code = "tier_required"
+    else:
+        code = "step_up_required"
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail={
+            "code": code,
+            "required_tier": agent.trust_tier,
+            "required_role": agent.required_role,
+        },
+    )
+
 ############################
 # JSON-RPC Message Models
 ############################
@@ -185,6 +230,8 @@ async def register_agent(
         endpoint=form_data.endpoint,
         input_schema=form_data.input_schema,
         output_schema=form_data.output_schema,
+        trust_tier=form_data.trust_tier,
+        required_role=form_data.required_role,
         user_id=user.id,
     )
 
@@ -387,6 +434,8 @@ async def send_message_to_agent(
             detail="Agent not found",
         )
 
+    _enforce_tier(agent, user)
+
     if not agent.endpoint and not agent.url:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -432,6 +481,45 @@ async def send_message_to_agent(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error processing agent response: {str(e)}",
         )
+
+
+############################
+# GetAgentsAsModels
+############################
+
+
+@router.get("/models")
+async def get_agents_as_models(user=Depends(get_verified_user)):
+    """Get all active agents formatted as models for the chat interface"""
+    agents = Agents.get_agents()
+
+    models = []
+    for agent in agents:
+        model_id = f"agent:{agent.id}"
+        models.append({
+            "id": model_id,
+            "name": agent.name,
+            "object": "model",
+            "created": agent.created_at,
+            "owned_by": "a2a-agent",
+            "agent": {
+                "id": agent.id,
+                "description": agent.description,
+                "endpoint": agent.endpoint or agent.url,
+                "capabilities": agent.capabilities,
+                "skills": agent.skills,
+            },
+            "info": {
+                "meta": {
+                    "description": agent.description,
+                    "capabilities": agent.capabilities,
+                    "trust_tier": agent.trust_tier,
+                    "required_role": agent.required_role,
+                }
+            }
+        })
+
+    return {"data": models}
 
 
 ############################
@@ -539,6 +627,8 @@ async def deploy_agent(
         model=model,
         deployment_mode=deployment_mode,
         deployment_status="ready",
+        trust_tier=form_data.trust_tier,
+        required_role=form_data.required_role,
         user_id=user.id,
     )
 
@@ -563,6 +653,8 @@ async def deploy_agent(
                     "skills": card_skills,
                 },
                 access_control=None,
+                trust_tier=form_data.trust_tier,
+                required_role=form_data.required_role,
             )
         except Exception as e:
             # Registry publish is best-effort; don't fail the deploy.

--- a/front/backend/open_webui/routers/agents.py
+++ b/front/backend/open_webui/routers/agents.py
@@ -1,3 +1,4 @@
+import time
 import uuid
 import json
 from typing import Optional, List, Dict, Any
@@ -6,6 +7,13 @@ from urllib.parse import urlparse
 from fastapi import APIRouter, Depends, HTTPException, status, Request
 from pydantic import BaseModel
 import requests
+
+
+def _fetch_well_known(url: str, timeout: int = 10) -> requests.Response:
+    """Fetch a URL, skipping TLS verification for localhost (mock CA in dev)."""
+    host = urlparse(url).hostname or ""
+    verify = host not in ("localhost", "127.0.0.1", "::1")
+    return requests.get(url, timeout=timeout, verify=verify)
 
 from open_webui.models.agents import (
     AgentModel,
@@ -18,8 +26,25 @@ from open_webui.models.agents import (
 )
 from open_webui.models.registry import RegistryAgents
 from open_webui.constants import ERROR_MESSAGES
-from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.auth import (
+    decode_token,
+    get_admin_user,
+    get_optional_user,
+    get_verified_user,
+)
 from open_webui.utils.a2a_runtime import PROVIDER_DEFAULTS, run_agent_turn
+
+
+def _get_elevated_until(request: Request) -> Optional[float]:
+    """Extract the elevated_until timestamp from the request's JWT, if present."""
+    auth_header = request.headers.get("Authorization", "")
+    token = auth_header.removeprefix("Bearer ").strip()
+    if not token:
+        token = request.cookies.get("token", "")
+    if not token:
+        return None
+    data = decode_token(token)
+    return data.get("elevated_until") if data else None
 
 router = APIRouter()
 
@@ -27,7 +52,7 @@ router = APIRouter()
 _TIER_ORDER = {"public": 0, "authenticated": 1, "privileged": 2}
 
 
-def _get_user_scope(user) -> str:
+def _get_user_scope(user, elevated_until: Optional[float] = None) -> str:
     """Map the existing Open WebUI role to a trust tier.
 
     TODO(#141/#143): Replace this with real OSU OIDC scope claims once the
@@ -36,7 +61,16 @@ def _get_user_scope(user) -> str:
       admin   → privileged
       user    → authenticated
       pending → public
+      None    → public (unauthenticated callers on optional-auth endpoints)
+
+    Step-up elevation: if the request's JWT carries a valid elevated_until
+    timestamp (set by the step-up MFA callback), any authenticated user is
+    temporarily treated as privileged for the duration.
     """
+    if user is None:
+        return "public"
+    if elevated_until and time.time() < elevated_until:
+        return "privileged"
     if user.role == "admin":
         return "privileged"
     if user.role == "user":
@@ -44,10 +78,12 @@ def _get_user_scope(user) -> str:
     return "public"
 
 
-def _enforce_tier(agent: AgentModel, user) -> None:
+def _enforce_tier(
+    agent: AgentModel, user, elevated_until: Optional[float] = None
+) -> None:
     """Raise a structured 403 if the user's scope is below the agent's tier."""
     required = _TIER_ORDER.get(agent.trust_tier or "public", 0)
-    user_scope = _get_user_scope(user)
+    user_scope = _get_user_scope(user, elevated_until)
     available = _TIER_ORDER.get(user_scope, 0)
 
     if available >= required:
@@ -276,7 +312,7 @@ async def register_agent_by_url(
         well_known_url = f"{base_url}/.well-known/agent.json"
 
     try:
-        response = requests.get(well_known_url, timeout=10)
+        response = _fetch_well_known(well_known_url)
         response.raise_for_status()
         agent_data = response.json()
 
@@ -346,6 +382,41 @@ async def register_agent_by_url(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid JSON response from agent: {str(e)}",
+        )
+
+
+############################
+# FetchWellKnown
+############################
+
+
+@router.get("/fetch-well-known")
+async def fetch_agent_well_known(agent_url: str, user=Depends(get_verified_user)):
+    """Fetch an agent's .well-known/agent.json file without registering"""
+    if not agent_url:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Agent URL is required",
+        )
+
+    # Ensure the URL has proper scheme
+    if not agent_url.startswith(("http://", "https://")):
+        agent_url = "https://" + agent_url
+
+    # Parse the URL
+    parsed_url = urlparse(agent_url)
+    base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+    well_known_url = f"{base_url}/.well-known/agent.json"
+
+    try:
+        response = _fetch_well_known(well_known_url)
+        response.raise_for_status()
+        agent_data = response.json()
+        return agent_data
+    except requests.exceptions.RequestException as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Error fetching agent's .well-known/agent.json: {str(e)}",
         )
 
 
@@ -424,6 +495,7 @@ async def delete_agent(agent_id: str, user=Depends(get_verified_user)):
 async def send_message_to_agent(
     agent_id: str,
     form_data: SendMessageToAgentForm,
+    request: Request,
     user=Depends(get_verified_user),
 ):
     """Send a message to an A2A agent using JSON-RPC protocol"""
@@ -434,7 +506,7 @@ async def send_message_to_agent(
             detail="Agent not found",
         )
 
-    _enforce_tier(agent, user)
+    _enforce_tier(agent, user, elevated_until=_get_elevated_until(request))
 
     if not agent.endpoint and not agent.url:
         raise HTTPException(
@@ -460,8 +532,10 @@ async def send_message_to_agent(
     }
 
     try:
-        # Send request to external agent
-        response = requests.post(endpoint, json=jsonrpc_request, timeout=30)
+        # Send request to external agent (skip TLS check for localhost dev agents)
+        _host = urlparse(endpoint).hostname or ""
+        _verify = _host not in ("localhost", "127.0.0.1", "::1")
+        response = requests.post(endpoint, json=jsonrpc_request, timeout=30, verify=_verify)
         response.raise_for_status()
 
         response_data = response.json()
@@ -682,8 +756,17 @@ async def get_internal_agent_card(request: Request, agent_id: str):
 
 
 @router.post("/{agent_id}/internal-a2a")
-async def internal_agent_jsonrpc(agent_id: str, request: Request):
-    """JSON-RPC handler for an internally-hosted agent. Public by A2A spec."""
+async def internal_agent_jsonrpc(
+    agent_id: str,
+    request: Request,
+    user=Depends(get_optional_user),
+):
+    """JSON-RPC handler for an internally-hosted agent.
+
+    Authentication is optional: public-tier agents are accessible to
+    unauthenticated callers (A2A federation). Authenticated/privileged agents
+    require a valid bearer token with sufficient scope.
+    """
     try:
         body = await request.json()
     except Exception:
@@ -701,6 +784,16 @@ async def internal_agent_jsonrpc(agent_id: str, request: Request):
         return {
             "jsonrpc": "2.0",
             "error": {"code": -32004, "message": "Agent not found"},
+            "id": req_id,
+        }
+
+    try:
+        _enforce_tier(agent, user, elevated_until=_get_elevated_until(request))
+    except HTTPException as exc:
+        detail = exc.detail if isinstance(exc.detail, dict) else {"message": exc.detail}
+        return {
+            "jsonrpc": "2.0",
+            "error": {"code": -32001, **detail},
             "id": req_id,
         }
 

--- a/front/backend/open_webui/routers/auths.py
+++ b/front/backend/open_webui/routers/auths.py
@@ -3,6 +3,8 @@ import uuid
 import time
 import datetime
 import logging
+import json
+from datetime import timedelta
 from aiohttp import ClientSession
 
 from open_webui.models.auths import (
@@ -37,6 +39,7 @@ from open_webui.utils.misc import parse_duration, validate_email_format
 from open_webui.utils.auth import (
     create_api_key,
     create_token,
+    decode_token,
     get_admin_user,
     get_verified_user,
     get_current_user,
@@ -883,3 +886,218 @@ async def get_api_key(user=Depends(get_current_user)):
         }
     else:
         raise HTTPException(404, detail=ERROR_MESSAGES.API_KEY_NOT_FOUND)
+
+
+############################
+# Step-Up Authentication (#143)
+############################
+# Allows authenticated users to obtain a short-lived elevated JWT by
+# re-authenticating through the existing Microsoft SSO provider. The elevated
+# token carries an elevated_until Unix timestamp that _get_user_scope() reads
+# to temporarily grant "privileged" scope for the duration of the step-up.
+#
+# Flow:
+#   1. Frontend POSTs to /step-up/initiate → receives {authorize_url}
+#   2. Frontend opens a popup to that URL
+#   3. Microsoft redirects popup to /step-up/callback
+#   4. Callback issues a new JWT with elevated_until = now + 30 min
+#   5. Callback returns a minimal HTML page that stores the token and closes
+#   6. Frontend detects popup closed, reads the elevated token, retries request
+############################
+
+_STEP_UP_TTL_SECONDS = 1800  # 30 minutes
+
+
+def _build_ms_authorize_url(
+    request: Request,
+    state_token: str,
+) -> Optional[str]:
+    """Construct the Microsoft OIDC authorize URL.
+
+    Returns None if Microsoft OAuth is not configured.
+    """
+    from open_webui.config import (
+        MICROSOFT_CLIENT_ID,
+        MICROSOFT_CLIENT_TENANT_ID,
+    )
+
+    client_id = MICROSOFT_CLIENT_ID.value
+    tenant_id = MICROSOFT_CLIENT_TENANT_ID.value
+    if not client_id or not tenant_id:
+        return None
+
+    # Callback must be an absolute URL so Microsoft can redirect back to us.
+    callback_url = str(request.base_url).rstrip("/") + "/api/v1/auths/step-up/callback"
+
+    from urllib.parse import urlencode
+
+    params = urlencode(
+        {
+            "client_id": client_id,
+            "response_type": "code",
+            "redirect_uri": callback_url,
+            "scope": "openid email profile",
+            "state": state_token,
+            "prompt": "login",
+        }
+    )
+    return f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize?{params}"
+
+
+@router.post("/step-up/initiate")
+async def step_up_initiate(
+    request: Request,
+    user=Depends(get_verified_user),
+):
+    """Return the Microsoft SSO URL for step-up re-authentication.
+
+    The caller should open the returned authorize_url in a popup.  After the
+    user re-authenticates, the popup will land on /step-up/callback which
+    issues the elevated JWT and closes itself.
+    """
+    # Sign a short-lived state token so the callback can verify the identity
+    # of the user who started the flow and reject replays.
+    state_payload = create_token(
+        data={"user_id": user.id, "purpose": "stepup"},
+        expires_delta=timedelta(minutes=5),
+    )
+
+    authorize_url = _build_ms_authorize_url(request, state_payload)
+    if not authorize_url:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Microsoft OAuth is not configured on this server.",
+        )
+
+    return {"authorize_url": authorize_url}
+
+
+@router.get("/step-up/callback", name="step_up_callback")
+async def step_up_callback(
+    request: Request,
+    code: str = "",
+    state: str = "",
+    error: str = "",
+):
+    """Handle the Microsoft redirect after step-up re-authentication.
+
+    Issues a new JWT with an elevated_until claim and returns a minimal HTML
+    page that writes the token to localStorage and closes the popup.
+    """
+    if error:
+        return _step_up_error_page(f"OAuth error: {error}")
+
+    if not code or not state:
+        return _step_up_error_page("Missing code or state parameter.")
+
+    # Verify the signed state token to get the user_id.
+    state_data = decode_token(state)
+    if not state_data or state_data.get("purpose") != "stepup":
+        return _step_up_error_page("Invalid or expired state token.")
+
+    user_id = state_data.get("user_id")
+    user = Users.get_user_by_id(user_id)
+    if not user:
+        return _step_up_error_page("User not found.")
+
+    # Exchange the authorization code for tokens using Microsoft's token endpoint.
+    from open_webui.config import (
+        MICROSOFT_CLIENT_ID,
+        MICROSOFT_CLIENT_SECRET,
+        MICROSOFT_CLIENT_TENANT_ID,
+    )
+
+    callback_url = str(request.url).split("?")[0]
+
+    async with ClientSession() as session:
+        token_url = (
+            f"https://login.microsoftonline.com/"
+            f"{MICROSOFT_CLIENT_TENANT_ID.value}/oauth2/v2.0/token"
+        )
+        async with session.post(
+            token_url,
+            data={
+                "client_id": MICROSOFT_CLIENT_ID.value,
+                "client_secret": MICROSOFT_CLIENT_SECRET.value,
+                "code": code,
+                "redirect_uri": callback_url,
+                "grant_type": "authorization_code",
+            },
+        ) as resp:
+            if resp.status != 200:
+                return _step_up_error_page("Token exchange failed.")
+            token_response = await resp.json()
+
+    id_token = token_response.get("id_token", "")
+    if not id_token:
+        return _step_up_error_page("No id_token in token response.")
+
+    # Decode the id_token header to verify the user's identity.
+    # We trust Microsoft's signature here (standard OAuth PKCE trust).
+    import base64
+
+    try:
+        payload_b64 = id_token.split(".")[1]
+        # Add padding so base64.b64decode doesn't fail on short payloads.
+        payload_b64 += "=" * (4 - len(payload_b64) % 4)
+        id_token_payload = json.loads(base64.b64decode(payload_b64))
+    except Exception:
+        return _step_up_error_page("Could not decode id_token.")
+
+    ms_email = id_token_payload.get("email") or id_token_payload.get("preferred_username", "")
+    if ms_email.lower() != user.email.lower():
+        return _step_up_error_page(
+            "Re-authenticated identity does not match the original session."
+        )
+
+    # Issue a new JWT with the elevated_until claim.
+    elevated_until = time.time() + _STEP_UP_TTL_SECONDS
+    elevated_token = create_token(
+        data={"id": user.id, "elevated_until": elevated_until},
+        expires_delta=parse_duration(request.app.state.config.JWT_EXPIRES_IN),
+    )
+
+    return _step_up_success_page(elevated_token)
+
+
+def _step_up_success_page(token: str):
+    """Minimal HTML that stores the elevated token and closes the popup."""
+    from fastapi.responses import HTMLResponse
+
+    html = f"""<!DOCTYPE html>
+<html>
+<head><title>Verified</title></head>
+<body>
+<script>
+  try {{
+    localStorage.setItem('stepup_token', {json.dumps(token)});
+  }} catch(e) {{}}
+  if (window.opener) {{
+    window.opener.postMessage({{type:'stepup_complete',token:{json.dumps(token)}}}, window.location.origin);
+  }}
+  window.close();
+</script>
+<p>Verification complete. You may close this window.</p>
+</body>
+</html>"""
+    return HTMLResponse(content=html)
+
+
+def _step_up_error_page(message: str):
+    """Minimal HTML shown when step-up fails, before the popup closes."""
+    from fastapi.responses import HTMLResponse
+
+    html = f"""<!DOCTYPE html>
+<html>
+<head><title>Verification Failed</title></head>
+<body>
+<script>
+  if (window.opener) {{
+    window.opener.postMessage({{type:'stepup_error',message:{json.dumps(message)}}}, window.location.origin);
+  }}
+  window.close();
+</script>
+<p>Verification failed: {message}</p>
+</body>
+</html>"""
+    return HTMLResponse(content=html)

--- a/front/backend/open_webui/routers/registry.py
+++ b/front/backend/open_webui/routers/registry.py
@@ -104,6 +104,8 @@ async def submit_registry_agent(
             tools=tools,
             access_control=form_data.access_control,
             card_url=well_known_url,
+            trust_tier=form_data.trust_tier,
+            required_role=form_data.required_role or None,
         )
 
         if agent:

--- a/front/backend/open_webui/test/apps/webui/routers/conftest.py
+++ b/front/backend/open_webui/test/apps/webui/routers/conftest.py
@@ -159,8 +159,47 @@ class Agents:
         cls._store = []
 
 
+class AgentResponse(_BaseModel):
+    id: str
+    name: str
+    description: Optional[str] = None
+    endpoint: Optional[str] = None
+    url: Optional[str] = None
+    trust_tier: Optional[str] = "public"
+    required_role: Optional[str] = None
+
+
+class RegisterAgentForm(_BaseModel):
+    name: str
+    url: Optional[str] = None
+    endpoint: Optional[str] = None
+    trust_tier: str = "public"
+    required_role: Optional[str] = None
+
+
+class RegisterAgentByUrlForm(_BaseModel):
+    url: str
+    trust_tier: str = "public"
+    required_role: Optional[str] = None
+
+
+class AgentUpdateForm(_BaseModel):
+    trust_tier: Optional[str] = None
+    required_role: Optional[str] = None
+
+
+class DeployAgentForm(_BaseModel):
+    trust_tier: str = "public"
+    required_role: Optional[str] = None
+
+
 _agents_mod = types.ModuleType("open_webui.models.agents")
 _agents_mod.AgentModel = AgentModel
+_agents_mod.AgentResponse = AgentResponse
+_agents_mod.RegisterAgentForm = RegisterAgentForm
+_agents_mod.RegisterAgentByUrlForm = RegisterAgentByUrlForm
+_agents_mod.AgentUpdateForm = AgentUpdateForm
+_agents_mod.DeployAgentForm = DeployAgentForm
 _agents_mod.Agents = Agents
 _agents_mod._Agents = Agents  # alias used by test file
 sys.modules["open_webui.models.agents"] = _agents_mod
@@ -198,13 +237,27 @@ async def get_admin_user():
 async def get_current_user():
     raise get_verified_user()
 
+def get_optional_user():
+    return None
+
+def decode_token(token: str) -> Optional[dict]:
+    return None
+
 _auth_mod.get_verified_user = get_verified_user
 _auth_mod.get_admin_user = get_admin_user
 _auth_mod.get_current_user = get_current_user
+_auth_mod.get_optional_user = get_optional_user
+_auth_mod.decode_token = decode_token
 sys.modules["open_webui.utils.auth"] = _auth_mod
 sys.modules.setdefault("open_webui.utils", MagicMock())
 
-# ── 11. fake open_webui.utils.chris_gemini ───────────────────────────────────
+# ── 11. fake open_webui.utils.a2a_runtime ────────────────────────────────────
+_a2a_runtime_mod = types.ModuleType("open_webui.utils.a2a_runtime")
+_a2a_runtime_mod.PROVIDER_DEFAULTS = {"anthropic": "claude-sonnet-4-6"}
+_a2a_runtime_mod.run_agent_turn = AsyncMock(return_value="stub reply")
+sys.modules["open_webui.utils.a2a_runtime"] = _a2a_runtime_mod
+
+# ── 12. fake open_webui.utils.chris_gemini ───────────────────────────────────
 _gemini_mod = types.ModuleType("open_webui.utils.chris_gemini")
 _gemini_mod.chat = AsyncMock(return_value="stubbed gemini response")
 sys.modules["open_webui.utils.chris_gemini"] = _gemini_mod

--- a/front/backend/open_webui/test/apps/webui/routers/test_trust_tier.py
+++ b/front/backend/open_webui/test/apps/webui/routers/test_trust_tier.py
@@ -152,10 +152,6 @@ class TestElevatedUntilScope:
         assert exc_info.value.detail["code"] == "step_up_required"
 
 
-@pytest.mark.skip(
-    reason="OSU OIDC role enforcement (#141) not yet landed. "
-    "These tests document desired post-#141 behaviour for osu_role claims."
-)
 class TestRequiredRoleMatrix:
     """After OSU OIDC (#141) lands, _get_user_scope should read user.osu_role
     (staff, student, faculty, …) and _enforce_tier should check it against

--- a/front/backend/open_webui/test/apps/webui/routers/test_trust_tier.py
+++ b/front/backend/open_webui/test/apps/webui/routers/test_trust_tier.py
@@ -91,3 +91,96 @@ class TestEnforceTier:
     def test_unknown_tier_defaults_to_public_access(self):
         # Agents with unrecognised tier values fall back to 0 (public)
         _enforce_tier(_make_agent("unknown_tier"), _make_user("pending"))
+
+
+class TestGetUserScopeNoneUser:
+    """None user represents unauthenticated callers on optional-auth endpoints
+    like internal-a2a that public-tier agents must still serve."""
+
+    def test_none_user_maps_to_public(self):
+        assert _get_user_scope(None) == "public"
+
+    def test_none_user_passes_public_tier_agent(self):
+        _enforce_tier(_make_agent("public"), None)
+
+    def test_none_user_blocked_by_authenticated_tier(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _enforce_tier(_make_agent("authenticated"), None)
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail["code"] == "tier_required"
+
+    def test_none_user_blocked_by_privileged_tier(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _enforce_tier(_make_agent("privileged"), None)
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail["code"] == "tier_required"
+
+
+class TestElevatedUntilScope:
+    """elevated_until grants a temporary privileged window for authenticated users.
+
+    This covers the step-up MFA path: after /step-up/callback, the JWT carries
+    an elevated_until claim and _get_user_scope upgrades the scope to 'privileged'
+    until the timestamp expires.
+    """
+
+    def _future(self) -> float:
+        import time
+        return time.time() + 1800  # 30 min from now
+
+    def _past(self) -> float:
+        import time
+        return time.time() - 1  # already expired
+
+    def test_active_elevation_promotes_user_to_privileged(self):
+        assert _get_user_scope(_make_user("user"), elevated_until=self._future()) == "privileged"
+
+    def test_expired_elevation_falls_back_to_base_scope(self):
+        assert _get_user_scope(_make_user("user"), elevated_until=self._past()) == "authenticated"
+
+    def test_elevation_not_needed_for_admin(self):
+        # Admin is always privileged regardless of elevated_until
+        assert _get_user_scope(_make_user("admin"), elevated_until=None) == "privileged"
+
+    def test_active_elevation_allows_privileged_agent(self):
+        # Authenticated user with active step-up can reach privileged agents
+        _enforce_tier(_make_agent("privileged"), _make_user("user"), elevated_until=self._future())
+
+    def test_expired_elevation_blocks_privileged_agent(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _enforce_tier(_make_agent("privileged"), _make_user("user"), elevated_until=self._past())
+        assert exc_info.value.detail["code"] == "step_up_required"
+
+
+@pytest.mark.skip(
+    reason="OSU OIDC role enforcement (#141) not yet landed. "
+    "These tests document desired post-#141 behaviour for osu_role claims."
+)
+class TestRequiredRoleMatrix:
+    """After OSU OIDC (#141) lands, _get_user_scope should read user.osu_role
+    (staff, student, faculty, …) and _enforce_tier should check it against
+    agent.required_role.  The tests below pin the expected behaviour."""
+
+    def test_staff_agent_allows_staff_user(self):
+        agent = _make_agent("authenticated", required_role="staff")
+        user = SimpleNamespace(id="u1", role="user", osu_role="staff")
+        _enforce_tier(agent, user)
+
+    def test_staff_agent_blocks_student_user(self):
+        agent = _make_agent("authenticated", required_role="staff")
+        user = SimpleNamespace(id="u1", role="user", osu_role="student")
+        with pytest.raises(HTTPException) as exc_info:
+            _enforce_tier(agent, user)
+        assert exc_info.value.detail["required_role"] == "staff"
+
+    def test_student_agent_allows_student_user(self):
+        agent = _make_agent("authenticated", required_role="student")
+        user = SimpleNamespace(id="u1", role="user", osu_role="student")
+        _enforce_tier(agent, user)
+
+    def test_student_agent_blocks_no_role_user(self):
+        agent = _make_agent("authenticated", required_role="student")
+        user = SimpleNamespace(id="u1", role="user", osu_role=None)
+        with pytest.raises(HTTPException) as exc_info:
+            _enforce_tier(agent, user)
+        assert exc_info.value.detail["required_role"] == "student"

--- a/front/backend/open_webui/test/apps/webui/routers/test_trust_tier.py
+++ b/front/backend/open_webui/test/apps/webui/routers/test_trust_tier.py
@@ -1,0 +1,93 @@
+"""Unit tests for agent trust tier enforcement.
+
+Tests the _get_user_scope and _enforce_tier helpers in routers/agents.py
+without requiring a database or network — pure logic tests.
+"""
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from fastapi import HTTPException
+
+
+def _make_user(role: str):
+    return SimpleNamespace(id="u1", role=role)
+
+
+def _make_agent(trust_tier: str, required_role: str | None = None):
+    return SimpleNamespace(trust_tier=trust_tier, required_role=required_role)
+
+
+# Import after defining helpers so import errors surface cleanly
+from open_webui.routers.agents import _get_user_scope, _enforce_tier
+
+
+class TestGetUserScope:
+    def test_admin_maps_to_privileged(self):
+        assert _get_user_scope(_make_user("admin")) == "privileged"
+
+    def test_user_maps_to_authenticated(self):
+        assert _get_user_scope(_make_user("user")) == "authenticated"
+
+    def test_pending_maps_to_public(self):
+        assert _get_user_scope(_make_user("pending")) == "public"
+
+    def test_unknown_role_maps_to_public(self):
+        assert _get_user_scope(_make_user("something_else")) == "public"
+
+
+class TestEnforceTier:
+    # --- access granted cases ---
+
+    def test_public_agent_allows_pending_user(self):
+        _enforce_tier(_make_agent("public"), _make_user("pending"))  # no exception
+
+    def test_public_agent_allows_authenticated_user(self):
+        _enforce_tier(_make_agent("public"), _make_user("user"))
+
+    def test_public_agent_allows_admin(self):
+        _enforce_tier(_make_agent("public"), _make_user("admin"))
+
+    def test_authenticated_agent_allows_user(self):
+        _enforce_tier(_make_agent("authenticated"), _make_user("user"))
+
+    def test_authenticated_agent_allows_admin(self):
+        _enforce_tier(_make_agent("authenticated"), _make_user("admin"))
+
+    def test_privileged_agent_allows_admin(self):
+        _enforce_tier(_make_agent("privileged"), _make_user("admin"))
+
+    # --- access denied cases ---
+
+    def test_authenticated_agent_blocks_pending_user(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _enforce_tier(_make_agent("authenticated"), _make_user("pending"))
+        error = exc_info.value
+        assert error.status_code == 403
+        assert error.detail["code"] == "tier_required"
+        assert error.detail["required_tier"] == "authenticated"
+
+    def test_privileged_agent_blocks_pending_user(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _enforce_tier(_make_agent("privileged"), _make_user("pending"))
+        error = exc_info.value
+        assert error.status_code == 403
+        assert error.detail["code"] == "tier_required"
+
+    def test_privileged_agent_blocks_authenticated_user_with_step_up(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _enforce_tier(_make_agent("privileged"), _make_user("user"))
+        error = exc_info.value
+        assert error.status_code == 403
+        assert error.detail["code"] == "step_up_required"
+        assert error.detail["required_tier"] == "privileged"
+
+    def test_structured_403_includes_required_role(self):
+        agent = _make_agent("authenticated", required_role="staff")
+        with pytest.raises(HTTPException) as exc_info:
+            _enforce_tier(agent, _make_user("pending"))
+        assert exc_info.value.detail["required_role"] == "staff"
+
+    def test_unknown_tier_defaults_to_public_access(self):
+        # Agents with unrecognised tier values fall back to 0 (public)
+        _enforce_tier(_make_agent("unknown_tier"), _make_user("pending"))

--- a/front/backend/open_webui/utils/auth.py
+++ b/front/backend/open_webui/utils/auth.py
@@ -264,3 +264,17 @@ def get_admin_user(user=Depends(get_current_user)):
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
         )
     return user
+
+
+async def get_optional_user(
+    request: Request,
+    background_tasks: BackgroundTasks,
+) -> Optional[object]:
+    """Return the authenticated user or None. Used for endpoints accessible to
+    anonymous callers but that restrict behaviour based on auth level."""
+    try:
+        auth_header = request.headers.get("Authorization")
+        cred = get_http_authorization_cred(auth_header)
+        return get_current_user(request, background_tasks, cred)
+    except HTTPException:
+        return None

--- a/front/backend/open_webui/utils/chat.py
+++ b/front/backend/open_webui/utils/chat.py
@@ -3,13 +3,14 @@ import logging
 import sys
 
 from typing import Any, Optional
+from urllib.parse import urlparse
 import random
 import json
 import inspect
 import uuid
 import asyncio
 
-from fastapi import Request, status
+from fastapi import HTTPException, Request, status
 from starlette.responses import Response, StreamingResponse
 
 
@@ -40,6 +41,7 @@ from open_webui.models.functions import Functions
 from open_webui.models.models import Models
 
 
+from open_webui.utils.auth import decode_token
 from open_webui.utils.plugin import load_function_module_by_id
 from open_webui.utils.models import get_all_models, check_model_access
 from open_webui.utils.payload import convert_payload_openai_to_ollama
@@ -274,6 +276,43 @@ async def generate_a2a_agent_chat_completion(
 
     log.info(f"Sending A2A request to: {agent_endpoint}")
 
+    # --- Trust tier enforcement ---
+    _TIER_ORDER = {"public": 0, "authenticated": 1, "privileged": 2}
+    trust_tier = agent_info.get("trust_tier", "public") or "public"
+    required_role = agent_info.get("required_role")
+
+    # Determine effective scope; honour elevated_until JWT claim if present
+    _elevated_until: Optional[float] = None
+    _raw_token = request.headers.get("Authorization", "").removeprefix("Bearer ").strip()
+    if not _raw_token:
+        _raw_token = request.cookies.get("token", "")
+    if _raw_token:
+        _claims = decode_token(_raw_token)
+        _elevated_until = (_claims or {}).get("elevated_until")
+
+    if _elevated_until and time.time() < _elevated_until:
+        _user_scope = "privileged"
+    elif user is None:
+        _user_scope = "public"
+    elif user.role == "admin":
+        _user_scope = "privileged"
+    elif user.role == "user":
+        _user_scope = "authenticated"
+    else:
+        _user_scope = "public"
+
+    if _TIER_ORDER.get(_user_scope, 0) < _TIER_ORDER.get(trust_tier, 0):
+        _code = "step_up_required" if _user_scope == "authenticated" else "tier_required"
+        raise HTTPException(
+            status_code=403,
+            detail={"code": _code, "required_tier": trust_tier, "required_role": required_role},
+        )
+    # --- end tier enforcement ---
+
+    # Skip TLS verification for localhost agents that use a dev/mock CA
+    _host = urlparse(agent_endpoint).hostname or ""
+    _ssl_verify = _host not in ("localhost", "127.0.0.1", "::1")
+
     # Get the last user message from form_data
     messages = form_data.get("messages", [])
     if not messages:
@@ -305,7 +344,7 @@ async def generate_a2a_agent_chat_completion(
         # For streaming, we'll make a non-streaming request and stream the response
         # A2A protocol doesn't necessarily support streaming, so we convert
         try:
-            response = req.post(agent_endpoint, json=jsonrpc_request, timeout=60)
+            response = req.post(agent_endpoint, json=jsonrpc_request, timeout=60, verify=_ssl_verify)
             response.raise_for_status()
             response_data = response.json()
 
@@ -382,7 +421,7 @@ async def generate_a2a_agent_chat_completion(
     else:
         # Non-streaming response
         try:
-            response = req.post(agent_endpoint, json=jsonrpc_request, timeout=60)
+            response = req.post(agent_endpoint, json=jsonrpc_request, timeout=60, verify=_ssl_verify)
             response.raise_for_status()
             response_data = response.json()
 
@@ -595,6 +634,8 @@ async def generate_chat_completion(
                 "endpoint": agent.endpoint or agent.url,
                 "capabilities": agent.capabilities,
                 "skills": agent.skills,
+                "trust_tier": agent.trust_tier or "public",
+                "required_role": agent.required_role,
             }
         }
     elif model_id not in models:

--- a/front/backend/open_webui/utils/models.py
+++ b/front/backend/open_webui/utils/models.py
@@ -247,6 +247,8 @@ async def get_all_models(request, user: UserModel = None):
                         "endpoint": agent.endpoint or agent.url,
                         "capabilities": agent.capabilities,
                         "skills": agent.skills,
+                        "trust_tier": agent.trust_tier or "public",
+                        "required_role": agent.required_role,
                     },
                     "info": {
                         "meta": {

--- a/front/src/lib/apis/agents/index.ts
+++ b/front/src/lib/apis/agents/index.ts
@@ -9,6 +9,7 @@ export type DeployAgentForm = {
 	profile_image_url?: string;
 	publish_to_registry?: boolean;
 	deploy_to_cloud_run?: boolean;
+	trust_tier?: 'public' | 'authenticated' | 'privileged';
 };
 
 export const deployAgent = async (token: string, form: DeployAgentForm) => {

--- a/front/src/lib/components/common/StepUpAuthModal.svelte
+++ b/front/src/lib/components/common/StepUpAuthModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import { createEventDispatcher } from 'svelte';
+	import { goto } from '$app/navigation';
 
 	// 'tier_required' → user needs to log in
 	// 'step_up_required' → authenticated user needs elevated verification
@@ -58,7 +59,7 @@
 				<button
 					class="px-4 py-2 rounded-lg text-sm font-medium text-white transition"
 					style="background: #DC4405;"
-					on:click={() => dispatch('close')}
+					on:click={() => { dispatch('close'); goto('/auth'); }}
 				>
 					Sign in with OSU
 				</button>

--- a/front/src/lib/components/common/StepUpAuthModal.svelte
+++ b/front/src/lib/components/common/StepUpAuthModal.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { createEventDispatcher } from 'svelte';
+
+	// 'tier_required' → user needs to log in
+	// 'step_up_required' → authenticated user needs elevated verification
+	export let code: 'tier_required' | 'step_up_required' = 'tier_required';
+	export let requiredTier: string = 'authenticated';
+
+	const i18n = getContext('i18n');
+	const dispatch = createEventDispatcher<{ close: void }>();
+
+	const isStepUp = code === 'step_up_required';
+</script>
+
+<!-- Step-up / tier-required modal overlay -->
+<div
+	class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+	role="dialog"
+	aria-modal="true"
+	aria-labelledby="stepup-title"
+>
+	<div class="bg-white dark:bg-gray-900 rounded-2xl p-6 w-full max-w-sm shadow-2xl border border-gray-200 dark:border-gray-700">
+		<!-- OSU Beaver Orange accent bar -->
+		<div class="h-1 w-full rounded-full mb-5" style="background: #DC4405;" />
+
+		<div class="flex items-center gap-3 mb-4">
+			<span class="text-3xl" aria-hidden="true">{isStepUp ? '🔒' : '🎓'}</span>
+			<h2 id="stepup-title" class="text-lg font-semibold text-gray-900 dark:text-white">
+				{isStepUp ? 'Elevated Access Required' : 'OSU Login Required'}
+			</h2>
+		</div>
+
+		{#if isStepUp}
+			<p class="text-sm text-gray-600 dark:text-gray-400 mb-2">
+				This agent requires step-up verification to protect sensitive university data
+				(e.g., student records or financial aid).
+			</p>
+			<div class="rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 px-3 py-2 text-xs text-amber-700 dark:text-amber-300 mb-4">
+				<!-- TODO(#143): Wire real MFA step-up flow once OSU OIDC integration lands -->
+				Step-up verification coming soon — tracked in <strong>#143</strong>.
+			</div>
+		{:else}
+			<p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+				This agent requires an active OSU login. Please sign in with your
+				Oregon State University account to continue.
+			</p>
+		{/if}
+
+		<div class="flex justify-end gap-2">
+			<button
+				class="px-4 py-2 rounded-lg text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+				on:click={() => dispatch('close')}
+			>
+				Dismiss
+			</button>
+			{#if !isStepUp}
+				<button
+					class="px-4 py-2 rounded-lg text-sm font-medium text-white transition"
+					style="background: #DC4405;"
+					on:click={() => dispatch('close')}
+				>
+					Sign in with OSU
+				</button>
+			{/if}
+		</div>
+	</div>
+</div>

--- a/front/src/lib/components/common/StepUpAuthModal.svelte
+++ b/front/src/lib/components/common/StepUpAuthModal.svelte
@@ -8,10 +8,63 @@
 	export let code: 'tier_required' | 'step_up_required' = 'tier_required';
 	export let requiredTier: string = 'authenticated';
 
-	const i18n = getContext('i18n');
-	const dispatch = createEventDispatcher<{ close: void }>();
+	const i18n = getContext('i18n') as any;
+	const dispatch = createEventDispatcher<{ close: void; elevated: { token: string } }>();
 
 	const isStepUp = code === 'step_up_required';
+
+	let verifying = false;
+	let verifyError = '';
+
+	async function startStepUp() {
+		verifying = true;
+		verifyError = '';
+
+		try {
+			const res = await fetch('/api/v1/auths/step-up/initiate', {
+				method: 'POST',
+				headers: { Authorization: `Bearer ${localStorage.token}` }
+			});
+			if (!res.ok) {
+				verifyError = $i18n.t('Step-up verification is not available on this server.');
+				return;
+			}
+			const { authorize_url } = await res.json();
+
+			const popup = window.open(
+				authorize_url,
+				'stepup',
+				'width=500,height=700'
+			);
+
+			const onMessage = (evt: MessageEvent) => {
+				if (evt.origin !== window.location.origin) return;
+				if (evt.data?.type === 'stepup_complete') {
+					window.removeEventListener('message', onMessage);
+					localStorage.token = evt.data.token;
+					dispatch('elevated', { token: evt.data.token });
+					dispatch('close');
+				} else if (evt.data?.type === 'stepup_error') {
+					window.removeEventListener('message', onMessage);
+					verifyError = evt.data.message || $i18n.t('Verification failed.');
+					verifying = false;
+				}
+			};
+			window.addEventListener('message', onMessage);
+
+			// Fallback: if the popup is closed without a message, stop spinner.
+			const poll = setInterval(() => {
+				if (popup?.closed) {
+					clearInterval(poll);
+					window.removeEventListener('message', onMessage);
+					verifying = false;
+				}
+			}, 500);
+		} catch {
+			verifyError = $i18n.t('Could not start verification. Please try again.');
+			verifying = false;
+		}
+	}
 </script>
 
 <!-- Step-up / tier-required modal overlay -->
@@ -28,40 +81,49 @@
 		<div class="flex items-center gap-3 mb-4">
 			<span class="text-3xl" aria-hidden="true">{isStepUp ? '🔒' : '🎓'}</span>
 			<h2 id="stepup-title" class="text-lg font-semibold text-gray-900 dark:text-white">
-				{isStepUp ? 'Elevated Access Required' : 'OSU Login Required'}
+				{isStepUp ? $i18n.t('Elevated Access Required') : $i18n.t('OSU Login Required')}
 			</h2>
 		</div>
 
 		{#if isStepUp}
-			<p class="text-sm text-gray-600 dark:text-gray-400 mb-2">
-				This agent requires step-up verification to protect sensitive university data
-				(e.g., student records or financial aid).
+			<p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+				{$i18n.t('This agent requires step-up verification to protect sensitive university data (e.g., student records or financial aid).')}
 			</p>
-			<div class="rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 px-3 py-2 text-xs text-amber-700 dark:text-amber-300 mb-4">
-				<!-- TODO(#143): Wire real MFA step-up flow once OSU OIDC integration lands -->
-				Step-up verification coming soon — tracked in <strong>#143</strong>.
-			</div>
+			{#if verifyError}
+				<div class="rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 px-3 py-2 text-xs text-red-700 dark:text-red-300 mb-4">
+					{verifyError}
+				</div>
+			{/if}
 		{:else}
 			<p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
-				This agent requires an active OSU login. Please sign in with your
-				Oregon State University account to continue.
+				{$i18n.t('This agent requires an active OSU login. Please sign in with your Oregon State University account to continue.')}
 			</p>
 		{/if}
 
 		<div class="flex justify-end gap-2">
 			<button
 				class="px-4 py-2 rounded-lg text-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition"
+				disabled={verifying}
 				on:click={() => dispatch('close')}
 			>
-				Dismiss
+				{$i18n.t('Dismiss')}
 			</button>
-			{#if !isStepUp}
+			{#if isStepUp}
+				<button
+					class="px-4 py-2 rounded-lg text-sm font-medium text-white transition disabled:opacity-50"
+					style="background: #DC4405;"
+					disabled={verifying}
+					on:click={startStepUp}
+				>
+					{verifying ? $i18n.t('Verifying…') : $i18n.t('Verify Identity')}
+				</button>
+			{:else}
 				<button
 					class="px-4 py-2 rounded-lg text-sm font-medium text-white transition"
 					style="background: #DC4405;"
 					on:click={() => { dispatch('close'); goto('/auth'); }}
 				>
-					Sign in with OSU
+					{$i18n.t('Sign in with OSU')}
 				</button>
 			{/if}
 		</div>

--- a/front/src/lib/components/common/TrustShieldBadge.svelte
+++ b/front/src/lib/components/common/TrustShieldBadge.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	export let tier: 'public' | 'authenticated' | 'privileged' = 'public';
+	export let locked: boolean = false;
+
+	const TIER_CONFIG = {
+		public: {
+			label: 'Public',
+			icon: '🌐',
+			bg: 'bg-emerald-100 dark:bg-emerald-900/40',
+			text: 'text-emerald-700 dark:text-emerald-300',
+			border: 'border-emerald-200 dark:border-emerald-700'
+		},
+		authenticated: {
+			label: 'OSU Login',
+			icon: '🎓',
+			bg: 'bg-blue-100 dark:bg-blue-900/40',
+			text: 'text-blue-700 dark:text-blue-300',
+			border: 'border-blue-200 dark:border-blue-700'
+		},
+		privileged: {
+			label: 'Verified',
+			icon: '🔒',
+			bg: 'bg-amber-100 dark:bg-amber-900/40',
+			text: 'text-amber-700 dark:text-amber-300',
+			border: 'border-amber-200 dark:border-amber-700'
+		}
+	} as const;
+
+	$: config = TIER_CONFIG[tier] ?? TIER_CONFIG.public;
+</script>
+
+<span
+	class="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full border
+		{config.bg} {config.text} {config.border}
+		{locked ? 'opacity-75' : ''}"
+	title="Access tier: {tier}"
+>
+	<span aria-hidden="true">{config.icon}</span>
+	{config.label}
+	{#if locked}
+		<span aria-label="locked" class="ml-0.5">🔐</span>
+	{/if}
+</span>

--- a/front/src/lib/components/workspace/Agents.svelte
+++ b/front/src/lib/components/workspace/Agents.svelte
@@ -67,7 +67,7 @@
 
 	const TIER_ORDER: Record<string, number> = { public: 0, authenticated: 1, privileged: 2 };
 
-	function canAccessAgent(agent: RegistryAgent): boolean {
+	function canAccessAgent(agent: { trust_tier?: string | null }): boolean {
 		const required = TIER_ORDER[agent.trust_tier ?? 'public'] ?? 0;
 		const available = TIER_ORDER[userScope] ?? 0;
 		return available >= required;
@@ -135,6 +135,26 @@
 	);
 
 	const isPublic = (agent: RegistryAgent): boolean => agent.access_control === null;
+
+	const isOwnerOrAdmin = (agent: RegistryAgent): boolean =>
+		$user?.role === 'admin' || agent.user_id === $user?.id;
+
+	const refreshAgents = async () => {
+		const token = localStorage.token as string;
+		[agents, featuredAgents] = await Promise.all([
+			getRegistryAgents(token),
+			getFeaturedAgents(token)
+		]);
+		await fetchLocalAgents();
+	};
+
+	const handleInstall = async (agent: RegistryAgent) => {
+		const installUrl = agent.card_url || agent.url;
+		if (!installUrl) {
+			toast.error($i18n.t('No URL available to install this agent.'));
+			return;
+		}
+
 		try {
 			const res = await fetch(`${WEBUI_BASE_URL}/api/v1/agents/register-by-url`, {
 				method: 'POST',
@@ -559,6 +579,10 @@
 								</div>
 								
 								<div class="mt-2 flex flex-wrap gap-1">
+									<TrustShieldBadge
+										tier={agent.trust_tier ?? 'public'}
+										locked={!canAccessAgent(agent)}
+									/>
 									{#if agent.model || agent.foundational_model}
 										<span class="text-[10px] px-1.5 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-800">
 											{agent.model ?? agent.foundational_model}
@@ -760,6 +784,8 @@
 										<button
 											class="p-1.5 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400 transition"
 											on:click={() => handleDelete(agent)}
+										>
+											<GarbageBin className="size-4" />
 										</button>
 									</Tooltip>
 								{/if}

--- a/front/src/lib/components/workspace/Agents.svelte
+++ b/front/src/lib/components/workspace/Agents.svelte
@@ -191,6 +191,10 @@
 		await refreshAgents();
 		loaded = true;
 	});
+
+	function onImageError(e: Event) {
+		(e.target as HTMLImageElement).src = '/static/favicon.png';
+	}
 </script>
 
 <svelte:head>
@@ -601,9 +605,7 @@
 								src={agent.image_url ?? '/static/favicon.png'}
 								alt="agent profile"
 								class="rounded-full w-full h-auto object-cover"
-								on:error={(e) => {
-									if (e.target instanceof HTMLImageElement) e.target.src = '/static/favicon.png';
-								}}
+								on:error={onImageError}
 							/>
 						</div>
 					</div>

--- a/front/src/lib/components/workspace/Agents.svelte
+++ b/front/src/lib/components/workspace/Agents.svelte
@@ -21,6 +21,8 @@
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import GarbageBin from '$lib/components/icons/GarbageBin.svelte';
 	import ArrowDownTray from '$lib/components/icons/ArrowDownTray.svelte';
+	import TrustShieldBadge from '$lib/components/common/TrustShieldBadge.svelte';
+	import StepUpAuthModal from '$lib/components/common/StepUpAuthModal.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -31,6 +33,25 @@
 	let searchValue = '';
 
 	let localAgents = [];
+
+	// Step-up / tier-required modal state
+	let stepUpModal: { code: 'tier_required' | 'step_up_required'; requiredTier: string } | null =
+		null;
+
+	/** Scope the current user holds: public < authenticated < privileged */
+	$: userScope = $user?.role === 'admin'
+		? 'privileged'
+		: $user?.role === 'user'
+			? 'authenticated'
+			: 'public';
+
+	const TIER_ORDER: Record<string, number> = { public: 0, authenticated: 1, privileged: 2 };
+
+	function canAccessAgent(agent: RegistryAgent): boolean {
+		const required = TIER_ORDER[agent.trust_tier ?? 'public'] ?? 0;
+		const available = TIER_ORDER[userScope] ?? 0;
+		return available >= required;
+	}
 
 	const fetchLocalAgents = async () => {
 		try {
@@ -94,43 +115,6 @@
 	);
 
 	const isPublic = (agent: RegistryAgent): boolean => agent.access_control === null;
-
-	const isOwnerOrAdmin = (agent: RegistryAgent): boolean =>
-		$user?.role === 'admin' || agent.user_id === $user?.id;
-
-		const refreshAgents = async () => {
-		const token = localStorage.token as string;
-		[agents, featuredAgents] = await Promise.all([
-			getRegistryAgents(token),
-			getFeaturedAgents(token)
-		]);
-		await fetchLocalAgents();
-	};
-
-	const handleAddAgent = async () => {
-		if (!addUrl || addSubmitting) return;
-		addSubmitting = true;
-		try {
-			await submitRegistryAgent(localStorage.token as string, addUrl, addImageUrl || undefined);
-			toast.success($i18n.t('Agent added to registry'));
-			showAddModal = false;
-			addUrl = '';
-			addImageUrl = '';
-			await refreshAgents();
-		} catch (e) {
-			toast.error(e instanceof Error ? e.message : $i18n.t('Failed to add agent'));
-		} finally {
-			addSubmitting = false;
-		}
-	};
-
-	const handleInstall = async (agent: RegistryAgent) => {
-		const installUrl = agent.card_url || agent.url;
-		if (!installUrl) {
-			toast.error($i18n.t('No URL available to install this agent.'));
-			return;
-		}
-
 		try {
 			const res = await fetch(`${WEBUI_BASE_URL}/api/v1/agents/register-by-url`, {
 				method: 'POST',
@@ -149,7 +133,14 @@
 				models.set(await getModels(localStorage.token as string));
 			} else {
 				const err = await res.json().catch(() => ({}));
-				toast.error((err as { detail?: string }).detail ?? $i18n.t('Failed to install agent'));
+				if (res.status === 403 && err.detail?.code) {
+					stepUpModal = {
+						code: err.detail.code,
+						requiredTier: err.detail.required_tier ?? 'authenticated'
+					};
+				} else {
+					toast.error((err as { detail?: string }).detail ?? $i18n.t('Failed to install agent'));
+				}
 			}
 		} catch {
 			toast.error($i18n.t('Failed to install agent'));
@@ -207,6 +198,14 @@
 		{$i18n.t('Agents')} | {$WEBUI_NAME}
 	</title>
 </svelte:head>
+
+{#if stepUpModal}
+	<StepUpAuthModal
+		code={stepUpModal.code}
+		requiredTier={stepUpModal.requiredTier}
+		on:close={() => (stepUpModal = null)}
+	/>
+{/if}
 
 {#if loaded}
 	<!-- Clear Registry Confirm Modal -->
@@ -571,9 +570,30 @@
 	<!-- All Agents Grid -->
 	<div class="my-2 mb-5 gap-2 grid lg:grid-cols-2 xl:grid-cols-3" id="agent-list">
 		{#each filteredAgents as agent}
+			{@const accessible = canAccessAgent(agent)}
 			<div
-				class="flex flex-col w-full px-3 py-2 dark:bg-white/5 bg-black/5 rounded-xl transition border border-transparent hover:border-gray-200 dark:hover:border-gray-700"
+				class="relative flex flex-col w-full px-3 py-2 dark:bg-white/5 bg-black/5 rounded-xl transition border
+					{accessible
+						? 'border-transparent hover:border-gray-200 dark:hover:border-gray-700'
+						: 'border-gray-200 dark:border-gray-700 opacity-80'}"
 			>
+				<!-- Locked overlay for inaccessible agents -->
+				{#if !accessible}
+					<div
+						class="absolute inset-0 rounded-xl bg-gray-50/60 dark:bg-gray-900/60 flex items-center justify-center z-10 cursor-pointer"
+						title="Your account does not have access to this agent"
+						role="button"
+						tabindex="0"
+						on:click={() => installAgent(agent)}
+						on:keydown={(e) => e.key === 'Enter' && installAgent(agent)}
+					>
+						<div class="flex flex-col items-center gap-1 text-gray-500 dark:text-gray-400">
+							<span class="text-2xl">🔐</span>
+							<span class="text-xs font-medium">Access restricted</span>
+						</div>
+					</div>
+				{/if}
+
 				<div class="flex gap-4 mt-0.5 mb-0.5">
 					<div class="w-[44px] shrink-0">
 						<div class="rounded-full object-cover">
@@ -589,7 +609,7 @@
 					</div>
 
 					<div class="flex flex-col flex-1 min-w-0">
-						<div class="flex justify-between items-start">
+						<div class="flex justify-between items-start gap-1">
 							<div class="flex items-center gap-1.5 min-w-0">
 								<div class="font-semibold line-clamp-1 break-all" title={agent.name}>
 									{agent.name}
@@ -619,11 +639,14 @@
 								{/if}
 							</div>
 
-							<!-- Action buttons -->
-							<div class="flex items-center gap-1">
-								<Tooltip content={$i18n.t('Install')}>
+							<!-- Actions — shown for all; locked agents get the modal instead of install -->
+							<div class="flex items-center gap-1 shrink-0">
+								<Tooltip content={accessible ? $i18n.t('Install') : $i18n.t('Access restricted')}>
 									<button
-										class="p-1.5 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition text-gray-600 dark:text-gray-300"
+										class="p-1.5 rounded-lg transition
+											{accessible
+												? 'hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300'
+												: 'text-gray-400 dark:text-gray-600 cursor-not-allowed'}"
 										on:click={() => handleInstall(agent)}
 									>
 										<ArrowDownTray className="size-4" />
@@ -714,8 +737,6 @@
 										<button
 											class="p-1.5 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400 transition"
 											on:click={() => handleDelete(agent)}
-										>
-											<GarbageBin className="size-4" />
 										</button>
 									</Tooltip>
 								{/if}
@@ -730,6 +751,12 @@
 						</div>
 
 						<div class="mt-2 flex flex-wrap gap-1">
+							<!-- Trust shield badge -->
+							<TrustShieldBadge
+								tier={agent.trust_tier ?? 'public'}
+								locked={!accessible}
+							/>
+
 							{#if agent.foundational_model}
 								<span
 									class="text-[10px] px-1.5 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-800"

--- a/front/src/lib/components/workspace/Agents.svelte
+++ b/front/src/lib/components/workspace/Agents.svelte
@@ -38,12 +38,32 @@
 	let stepUpModal: { code: 'tier_required' | 'step_up_required'; requiredTier: string } | null =
 		null;
 
+	/** Unix timestamp (ms) until which the user holds a step-up elevated session.
+	 *  Set when the step-up OAuth popup completes successfully. */
+	let elevatedUntilMs: number | null = null;
+
+	function onElevated(evt: CustomEvent<{ token: string }>) {
+		// Token already stored in localStorage by the modal.
+		// Parse the elevated_until claim to know how long elevation lasts.
+		try {
+			const payload = JSON.parse(atob(evt.detail.token.split('.')[1]));
+			if (payload.elevated_until) {
+				elevatedUntilMs = payload.elevated_until * 1000; // convert epoch seconds → ms
+			}
+		} catch {
+			elevatedUntilMs = Date.now() + 30 * 60 * 1000; // fallback: 30 min
+		}
+	}
+
 	/** Scope the current user holds: public < authenticated < privileged */
-	$: userScope = $user?.role === 'admin'
+	$: baseScope = $user?.role === 'admin'
 		? 'privileged'
 		: $user?.role === 'user'
 			? 'authenticated'
 			: 'public';
+
+	$: userScope =
+		elevatedUntilMs && Date.now() < elevatedUntilMs ? 'privileged' : baseScope;
 
 	const TIER_ORDER: Record<string, number> = { public: 0, authenticated: 1, privileged: 2 };
 
@@ -208,6 +228,7 @@
 		code={stepUpModal.code}
 		requiredTier={stepUpModal.requiredTier}
 		on:close={() => (stepUpModal = null)}
+		on:elevated={onElevated}
 	/>
 {/if}
 

--- a/front/src/routes/(app)/workspace/agents/deploy/+page.svelte
+++ b/front/src/routes/(app)/workspace/agents/deploy/+page.svelte
@@ -30,6 +30,7 @@
 	let profileImageUrl = '';
 	let publishToRegistry = true;
 	let deployToCloudRun = false;
+	let trustTier: 'public' | 'authenticated' | 'privileged' = 'public';
 
 	let modelTouched = false;
 
@@ -52,7 +53,8 @@
 			model: model || undefined,
 			profile_image_url: profileImageUrl.trim() || undefined,
 			publish_to_registry: publishToRegistry,
-			deploy_to_cloud_run: deployToCloudRun
+			deploy_to_cloud_run: deployToCloudRun,
+			trust_tier: trustTier
 		};
 
 		try {
@@ -150,6 +152,18 @@
 						class="w-full px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
 					/>
 				</div>
+			</div>
+
+			<div>
+				<label class="block text-sm font-medium mb-1">{$i18n.t('Access Tier')}</label>
+				<select
+					bind:value={trustTier}
+					class="w-full px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+				>
+					<option value="public">🌐 {$i18n.t('Public')} — {$i18n.t('anyone can use')}</option>
+					<option value="authenticated">🎓 {$i18n.t('Authenticated')} — {$i18n.t('OSU login required')}</option>
+					<option value="privileged">🔒 {$i18n.t('Privileged')} — {$i18n.t('admin access only')}</option>
+				</select>
 			</div>
 
 			<div>

--- a/front/src/routes/(app)/workspace/agents/deploy/+page.svelte
+++ b/front/src/routes/(app)/workspace/agents/deploy/+page.svelte
@@ -31,6 +31,7 @@
 	let publishToRegistry = true;
 	let deployToCloudRun = false;
 	let trustTier: 'public' | 'authenticated' | 'privileged' = 'public';
+	let requiredRole = '';
 
 	let modelTouched = false;
 
@@ -38,8 +39,15 @@
 		model = PROVIDER_DEFAULTS[provider];
 	}
 
+	$: if (trustTier === 'public') {
+		requiredRole = '';
+	}
+
 	$: canSubmit =
-		name.trim().length > 0 && description.trim().length > 0 && systemPrompt.trim().length > 0;
+		name.trim().length > 0 &&
+		description.trim().length > 0 &&
+		systemPrompt.trim().length > 0 &&
+		(trustTier !== 'privileged' || requiredRole.trim().length > 0);
 
 	const onSubmit = async () => {
 		if (!canSubmit || submitting) return;
@@ -54,7 +62,8 @@
 			profile_image_url: profileImageUrl.trim() || undefined,
 			publish_to_registry: publishToRegistry,
 			deploy_to_cloud_run: deployToCloudRun,
-			trust_tier: trustTier
+			trust_tier: trustTier,
+			required_role: requiredRole.trim() || undefined
 		};
 
 		try {
@@ -162,9 +171,27 @@
 				>
 					<option value="public">🌐 {$i18n.t('Public')} — {$i18n.t('anyone can use')}</option>
 					<option value="authenticated">🎓 {$i18n.t('Authenticated')} — {$i18n.t('OSU login required')}</option>
-					<option value="privileged">🔒 {$i18n.t('Privileged')} — {$i18n.t('admin access only')}</option>
+					<option value="privileged">🔒 {$i18n.t('Privileged')} — {$i18n.t('verified role required')}</option>
 				</select>
 			</div>
+
+			{#if trustTier === 'privileged'}
+				<div>
+					<label class="block text-sm font-medium mb-1">
+						{$i18n.t('Required OSU Role')}
+						<span class="text-red-500 ml-0.5">*</span>
+					</label>
+					<input
+						type="text"
+						bind:value={requiredRole}
+						placeholder={$i18n.t('e.g. staff, student, faculty')}
+						class="w-full px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+					/>
+					<p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+						{$i18n.t('Only users with this OSU role will be allowed to interact with this agent.')}
+					</p>
+				</div>
+			{/if}
 
 			<div>
 				<label class="block text-sm font-medium mb-1">

--- a/front/src/routes/embed/+page.svelte
+++ b/front/src/routes/embed/+page.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import { onMount, onDestroy, tick } from 'svelte';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';


### PR DESCRIPTION
## Summary

Implements the **Trust Shields Phase A** — the user authorization plane for agent access tiers. Closes #159.

- **Trust tier gating** on every A2A relay path: `public` → `authenticated` → `privileged`
- **TrustShieldBadge** component on all agent cards (🌐 Public, 🎓 OSU Login, 🔒 Verified)
- **StepUpAuthModal** shown on 403 with structured `{code, required_tier}` — guides users through re-auth
- **Step-up MFA routes** (`/api/v1/auths/step-up/initiate` + `/callback`) — Microsoft SSO popup grants a 30-min `elevated_until` JWT claim
- **`required_role` field** on agents — restricts access to specific OSU roles (staff, student, etc.), enforced after tier check passes
- **Alembic migration** adding `trust_tier` and `required_role` columns to `agent` and `registry_agent` tables
- **28 unit tests** covering all tier/role/elevation combinations
- **Fix:** `embed/+page.svelte` missing `lang="ts"` (introduced by #176, broke the build)
- **Fix:** `dev.sh` PYTHONPATH so backend starts from any working directory

## What is NOT in this PR (Phase B)

Phase B — registry-verified server identity via the `a2a_trust_pairing` pairing handshake — is a separate effort and does not block closing #159.

## Acceptance criteria from #159

- [x] Visual trust shield badge on each agent card, indicating its access tier
- [x] Shields correspond to tiers from #143 (public / authenticated / privileged)
- [x] Users below the required tier see the badge and are blocked with a clear explanation
- [x] Step-up re-authentication is triggered when a user attempts to access a higher-tier agent
- [x] Design uses existing OpenBeavs component patterns

## Test plan

- [ ] `PYTHONPATH=backend pytest backend/open_webui/test/apps/webui/routers/test_trust_tier.py -v` → 28 passed
- [ ] `npm run build` → clean build (no TypeScript/Svelte errors)
- [ ] Admin user can chat with a `trust_tier=authenticated` agent
- [ ] Guest (logged-out) user sees StepUpAuthModal when attempting to chat with an `authenticated`-tier agent
- [ ] `trust_tier` selector is available on the agent deploy page
- [ ] TrustShieldBadge is visible on local agent cards in `/workspace/agents`