### PR TITLE
Finalizing the project.

### DIFF
--- a/.agents/skills/openbeavs-admin/SKILL.md
+++ b/.agents/skills/openbeavs-admin/SKILL.md
@@ -1,0 +1,559 @@
+---
+name: openbeavs-admin
+description: Operate a running OpenBeavs / GENESIS-AI-Hub instance over its REST API. USE THIS SKILL whenever the user asks to list agents, list users, list models, deploy an agent, register an A2A agent by URL, delete an agent, promote a user, mint a service-account bearer token, query the public registry, or health-check a hub — local or deployed. The skill documents the auth flow (POST /api/v1/auths/signin → bearer token), the trailing-slash quirk on collection endpoints (e.g. /api/v1/agents/ vs /api/v1/agents), the dev placeholder admin (admin@gmail.com / 1234), and the response shapes for the highest-traffic routes. Reads OPENBEAVS_BASE_URL and OPENBEAVS_ADMIN_TOKEN from the environment; if either is missing, ask the user before guessing.
+---
+
+# OpenBeavs admin skill
+
+This skill teaches you how to drive a running OpenBeavs hub using `curl`. The
+hub is a FastAPI service at `front/backend/open_webui/`; routers live under
+`front/backend/open_webui/routers/`. When something here looks wrong, the
+routers are the source of truth — open the file referenced in the section.
+
+## Prerequisites — token and base URL
+
+Before any request, both env vars must be set in the bash session:
+
+- `OPENBEAVS_BASE_URL` — e.g. `http://localhost:8080` for local dev, or
+  the Cloud Run URL of the active hub for prod.
+- `OPENBEAVS_ADMIN_TOKEN` — a bearer token belonging to an `admin` role
+  user. Either pull it from browser DevTools (`localStorage.token` after
+  signing in via the UI) or call the signin endpoint below.
+
+If either is missing, ask the user this exact question before doing
+anything else:
+
+> "I need `OPENBEAVS_BASE_URL` and `OPENBEAVS_ADMIN_TOKEN` to talk to the
+> hub. What's the base URL, and do you have an admin token already, or
+> would you like me to walk through `signin`?"
+
+Never invent a URL. Never paste a token into the conversation; the user
+should `export` it themselves. Treat the token like a password — do not
+echo it back, do not write it to disk, and remind the user to unset it
+when done (`unset OPENBEAVS_ADMIN_TOKEN`).
+
+### Default placeholder admin (dev/staging only)
+
+The deployed dev/staging hub seeds a placeholder admin account:
+
+- email: `admin@gmail.com`
+- password: `1234`
+
+**Use these only after the user confirms the hub is in dev/staging
+mode** — never assume them for prod. If the user has not confirmed,
+ask: "Is this hub using the placeholder `admin@gmail.com / 1234`
+admin, or do you have your own admin credentials?" Do NOT default to
+the email in `userEmail`/the harness context — that account almost
+certainly has no admin role on the hub.
+
+### Quick start — copy this exactly
+
+> **Note on env-var scope.** `!`-prefix lines in the Codex prompt and
+> Codex's own Bash tool calls each spawn a fresh subshell —
+> `export`s done in one subshell do NOT survive into later calls. So
+> if the user `!export`s the vars from inside Codex, those exports
+> are gone by the time Codex tries to run a curl.
+>
+> **How the skill should handle this:** if a Bash tool call shows
+> `OPENBEAVS_BASE_URL` empty or `OPENBEAVS_ADMIN_TOKEN` unset, just
+> silently re-auth in a single Bash call (sign in + use the token in
+> the same heredoc or `&&` chain). It's faster than asking the user
+> to exit and re-launch, and the placeholder dev creds are harmless.
+> Mention afterwards (one short line) that for persistence across
+> turns the user can `export` both in the terminal **before** running
+> `Codex` — that way every subsequent Bash tool call inherits them
+> and you don't need to re-auth on every request.
+>
+> The exception: re-auth ONLY when the email/password are already
+> known (placeholder dev admin, or stored from earlier this session).
+> If neither var is set AND no creds are known, ask the user.
+
+The fastest way to get a working session, with the trailing slash
+already correct. The user can either run these in their terminal
+*before* `Codex` (preferred — exports persist for the whole
+session), or paste the same block as one Bash call inside Codex
+(works for one turn):
+
+```bash
+# In your terminal, BEFORE running `Codex`:
+export OPENBEAVS_BASE_URL="https://openbeavs-deploy-test-<hash>.us-west1.run.app"
+export OPENBEAVS_ADMIN_TOKEN=$(curl -s -X POST \
+  "$OPENBEAVS_BASE_URL/api/v1/auths/signin" \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@gmail.com","password":"1234"}' \
+  | jq -r .token)
+
+Codex   # Codex inherits both vars in every Bash tool call
+```
+
+Once inside Codex, the very first thing the skill does is verify
+both vars are populated:
+
+```bash
+echo "URL: $OPENBEAVS_BASE_URL"
+echo "TOKEN set: $([ -n "$OPENBEAVS_ADMIN_TOKEN" ] && echo yes || echo no)"
+
+# Confirm the token works AND you got JSON back (not HTML):
+curl -fsS "$OPENBEAVS_BASE_URL/api/v1/auths/" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  | jq '{id,email,role}'
+
+# List local agents — note the TRAILING SLASH:
+curl -fsS "$OPENBEAVS_BASE_URL/api/v1/agents/" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" | jq
+```
+
+If the env-check shows either var empty and the placeholder dev
+creds apply, re-auth in-line in the same Bash call and proceed:
+
+```bash
+BASE="${OPENBEAVS_BASE_URL:-https://openbeavs-deploy-test-<hash>.us-west1.run.app}"
+TOKEN="${OPENBEAVS_ADMIN_TOKEN:-$(curl -s -X POST "$BASE/api/v1/auths/signin" \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@gmail.com","password":"1234"}' | jq -r .token)}"
+curl -fsS "$BASE/api/v1/agents/" -H "Authorization: Bearer $TOKEN" | jq
+```
+
+Use `curl -fsS` (fail-fast on HTTP errors) and pipe through `jq` so an
+HTML body fails loudly. If `jq` errors with "parse error", you almost
+certainly forgot the trailing slash on a collection endpoint.
+
+### Finding the prod URL
+
+The active prod service is `openbeavs-deploy-test` in project
+`osu-genesis-hub`, region `us-west1`. Other Cloud Run services
+(`openbeavs-main`, `genesis-ai-hub-backend`) are placeholders or stale
+deployments — `openbeavs-main` returns the SvelteKit shell with no
+backend wired, so any API call will look like it "works" (HTTP 200 +
+HTML) until you parse the body. **Always ask the user which hub** before
+hitting `gcloud run services list`; if you must list, only trust
+`openbeavs-deploy-test`.
+
+### CRITICAL — trailing-slash quirk
+
+Collection endpoints (the ones whose path ends at the router prefix)
+**require a trailing slash**:
+
+- ✅ `GET /api/v1/agents/` → JSON list from FastAPI
+- ❌ `GET /api/v1/agents`  → SvelteKit shell, HTTP 200, `text/html`
+
+This bites because the response is a 200, not a redirect or 404 — a
+no-slash request silently returns the frontend HTML. If a curl returns
+HTML where you expected JSON, the first thing to check is the trailing
+slash. The same pattern applies to `/api/v1/users/`, `/api/v1/models/`,
+`/api/v1/registry/`, `/api/v1/auths/`, and any other root-of-router GET.
+Sub-paths (`/api/v1/agents/all`, `/api/v1/agents/{id}`) do NOT need the
+trailing slash — only the collection root does.
+
+Always pipe JSON-expecting responses through `jq` (or `python3 -m
+json.tool`) so an accidental HTML body fails loudly instead of
+spreading downstream.
+
+## Auth surface — `/api/v1/auths`
+
+Source: `front/backend/open_webui/routers/auths.py`.
+
+### POST /api/v1/auths/signin (public)
+
+Body: `{ "email": str, "password": str }`.
+
+Response (`SigninResponse`) — fields:
+
+| Field               | Type        | Meaning                                                          |
+|---------------------|-------------|------------------------------------------------------------------|
+| `token`             | str (JWT)   | Bearer token. Pass as `Authorization: Bearer <token>`.           |
+| `token_type`        | str         | Always `"Bearer"`.                                               |
+| `expires_at`        | int \| null | Unix epoch seconds. Null when `JWT_EXPIRES_IN=-1` (no expiry).   |
+| `id`                | str         | User ID for the signed-in account.                               |
+| `email`             | str         | Lowercased email.                                                |
+| `name`              | str         | Display name.                                                    |
+| `role`              | str         | `"pending"`, `"user"`, or `"admin"` — verify this is `"admin"` before using the token for admin routes. |
+| `profile_image_url` | str         | Avatar URL.                                                      |
+| `permissions`       | dict        | Resolved permission map for the user's role + group membership.  |
+
+Errors:
+- `400 "The email or password provided is incorrect..."` — bad creds.
+- `403` — pending or disabled account.
+
+Have the user run this in their own terminal so the password never
+enters the chat:
+
+```bash
+read -rsp 'password: ' PASS && echo
+curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/auths/signin" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg e "$EMAIL" --arg p "$PASS" '{email:$e,password:$p}')" \
+  | jq -r .token
+unset PASS
+```
+
+### GET /api/v1/auths/ (verified user)
+
+Verify the current token works and inspect the caller's role:
+
+```bash
+curl -s "$OPENBEAVS_BASE_URL/api/v1/auths/" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  | jq '{id,email,role}'
+```
+
+### POST /api/v1/auths/add (admin only)
+
+Mints a new user **and returns a bearer token for that user** in the
+same response. Body matches `AddUserForm`:
+
+```
+{ "name": str, "email": str, "password": str,
+  "profile_image_url": str (optional, defaults to "/user.png"),
+  "role": "pending" | "user" | "admin" (optional, defaults to "pending") }
+```
+
+The returned `token` is the only copy. Print it once, warn the user it
+cannot be re-fetched, and do not store it anywhere.
+
+```bash
+curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/auths/add" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"CI Bot","email":"ci@example.com","password":"...","role":"user"}' \
+  | jq
+```
+
+## Agents — `/api/v1/agents`
+
+Source: `front/backend/open_webui/routers/agents.py`. An "agent" here is
+a row in the `agent` table representing an A2A endpoint installed on
+this hub. `deployment_mode` is one of: `internal` (served in-process by
+the hub itself), `cloud_run` (separate Cloud Run service), or absent
+(externally registered via URL).
+
+### GET /api/v1/agents/ (verified user)
+
+Returns active agents visible to the caller. Response: `List[AgentResponse]`.
+Note this is a *trimmed* shape — for the full agent record (provider, model,
+system_prompt, deployment_mode), use `/all` or `/{agent_id}`.
+
+Per-row fields:
+
+| Field          | Type                  | Meaning                                              |
+|----------------|-----------------------|------------------------------------------------------|
+| `id`           | str (uuid)            | Stable agent ID; use this in path params.            |
+| `name`         | str                   | Display name from the discovery card or deploy form. |
+| `description`  | str                   | Short description for the workspace card.            |
+| `endpoint`     | str \| null           | A2A JSON-RPC POST URL. `null` for URL-only registrations. |
+| `url`          | str \| null           | Base homepage URL. Always present; chat path falls back to `url` when `endpoint` is null. |
+| `capabilities` | dict \| null          | A2A capability flags, typically `{"streaming": bool}`. |
+| `skills`       | list[dict] \| null    | Discovery-card skills array.                         |
+| `is_active`    | bool                  | Soft-delete / disable flag.                          |
+
+```bash
+curl -fsS "$OPENBEAVS_BASE_URL/api/v1/agents/" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  | jq '.[] | {id,name,endpoint,url,is_active}'
+```
+
+### GET /api/v1/agents/all (admin)
+
+Includes inactive rows AND returns the full `AgentModel` shape — adds
+these fields on top of the trimmed list above:
+
+| Field               | Type           | Meaning                                                                                  |
+|---------------------|----------------|------------------------------------------------------------------------------------------|
+| `version`           | str \| null    | Discovery-card version, e.g. `"1.0.0"`.                                                  |
+| `default_input_modes`  | list[str]   | A2A input modalities; usually `["text"]`.                                                |
+| `default_output_modes` | list[str]   | A2A output modalities; usually `["text"]`.                                               |
+| `input_schema`      | dict \| null   | Optional JSON schema for input validation.                                               |
+| `output_schema`     | dict \| null   | Optional JSON schema for output validation.                                              |
+| `profile_image_url` | str \| null    | Avatar URL; `/static/favicon.png` is the default fallback.                               |
+| `system_prompt`     | str \| null    | Set only for agents created via `/deploy`. Null for URL-registered agents.               |
+| `provider`          | str \| null    | `"anthropic"`, `"openai"`, or `"gemini"` for deployed agents; null otherwise.            |
+| `model`             | str \| null    | Provider-specific model id (e.g. `"Codex-sonnet-4-6"`).                                 |
+| `deployment_mode`   | str \| null    | `"internal"` (in-process), `"cloud_run"` (separate service), or null (externally registered). |
+| `deployment_status` | str \| null    | `"ready"` is the only state currently emitted by `/deploy`.                              |
+| `created_at`        | int            | Unix epoch seconds.                                                                      |
+| `updated_at`        | int            | Unix epoch seconds.                                                                      |
+| `user_id`           | str \| null    | Owner. Admins can see all rows; non-admins see only their own.                           |
+
+How to read `deployment_mode` quickly:
+
+- `null` → registered by URL via `/register-by-url`. The hub does not
+  host this agent; chat traffic goes to `endpoint || url`.
+- `"internal"` → the hub itself serves the agent in-process. The
+  `endpoint` will be `{base_url}/api/v1/agents/{id}/internal-a2a`. Chat
+  traffic short-circuits the HTTP round-trip via `utils/chat.py`.
+- `"cloud_run"` → a separate Cloud Run service was provisioned at
+  deploy time. `endpoint` is that service's URL.
+
+### GET /api/v1/agents/{agent_id} (verified)
+
+Returns one full `AgentModel` (same shape as `/all` rows). 404 if the
+ID does not exist; 401 if a non-admin requests an agent they don't
+own.
+
+### POST /api/v1/agents/register-by-url (verified)
+
+Fetches the target's `/.well-known/agent.json`, parses the discovery
+card, and inserts an agent row. Body: `RegisterAgentByUrlForm`:
+
+```
+{ "agent_url": str, "profile_image_url": str (optional) }
+```
+
+```bash
+curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/agents/register-by-url" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"agent_url":"https://weather.example.com"}' | jq
+```
+
+### POST /api/v1/agents/deploy (admin) — destructive on prod
+
+Creates a brand-new internally-hosted A2A agent. Body: `DeployAgentForm`:
+
+```
+{ "name": str, "description": str, "system_prompt": str,
+  "provider": "anthropic" | "openai" | "gemini" (default "anthropic"),
+  "model": str (optional; provider default applied if omitted),
+  "profile_image_url": str (optional),
+  "publish_to_registry": bool (default true),
+  "deploy_to_cloud_run": bool (default false) }
+```
+
+If `deploy_to_cloud_run` is true on prod, the hub gates this with
+`OPENBEAVS_CLOUD_RUN_DISABLED=1` and returns 503. For internal-mode
+deploys, the hub stores `endpoint = {base_url}/api/v1/agents/{id}/internal-a2a`
+and serves the agent in-process.
+
+```bash
+curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/agents/deploy" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name":"WeatherBot",
+    "description":"Answers Oregon weather questions",
+    "system_prompt":"You are a concise weather assistant.",
+    "provider":"anthropic"
+  }' | jq
+```
+
+### DELETE /api/v1/agents/{agent_id} (verified, owner-or-admin)
+
+```bash
+curl -s -X DELETE "$OPENBEAVS_BASE_URL/api/v1/agents/$AGENT_ID" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN"
+```
+
+## Users — `/api/v1/users`
+
+Source: `front/backend/open_webui/routers/users.py`.
+
+### GET /api/v1/users/ (admin)
+
+Pagination via `?skip=&limit=`. Returns `List[UserModel]`.
+
+Per-row fields:
+
+| Field               | Type        | Meaning                                                            |
+|---------------------|-------------|--------------------------------------------------------------------|
+| `id`                | str (uuid)  | Stable user ID; use in `/update/role` and `/{id}/update`.          |
+| `email`             | str         | Lowercased on insert. Login key.                                   |
+| `name`              | str         | Display name.                                                      |
+| `role`              | str         | `"pending"` (signup queued, no access), `"user"`, or `"admin"`.    |
+| `profile_image_url` | str         | Avatar URL; `/user.png` is the default fallback.                   |
+| `last_active_at`    | int \| null | Unix epoch seconds of last token verification.                     |
+| `created_at`        | int         | Unix epoch seconds.                                                |
+| `updated_at`        | int         | Unix epoch seconds.                                                |
+| `api_key`           | str \| null | Set if the user generated a personal API key via `/api/v1/auths/api_key`. |
+| `settings`          | dict \| null | Per-user UI preferences blob.                                     |
+| `info`              | dict \| null | Free-form admin notes.                                            |
+
+```bash
+curl -fsS "$OPENBEAVS_BASE_URL/api/v1/users/?limit=200" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  | jq '.[] | {id,email,role,last_active_at}'
+```
+
+`role == "pending"` is the most common gotcha — new signups are queued
+in this state until an admin promotes them via `/update/role`. They
+can sign in but can't read any resource.
+
+### POST /api/v1/users/update/role (admin)
+
+Body: `{ "id": str, "role": "pending" | "user" | "admin" }`. Note the
+hub refuses to demote the first-ever user (the bootstrap admin).
+
+```bash
+curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/users/update/role" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"<user-id>","role":"admin"}' | jq
+```
+
+### POST /api/v1/users/{user_id}/update (admin) — destructive
+
+Body: `UserUpdateForm = { name, email, profile_image_url, password? }`.
+Overwrites all four fields; pass current values for ones you don't want
+to change.
+
+### DELETE /api/v1/users/{user_id} (admin) — destructive
+
+## Models — `/api/v1/models`
+
+Source: `front/backend/open_webui/routers/models.py`. Note the per-model
+endpoints take `id` as a **query parameter**, not a path component, so
+slashes in IDs (`anthropic/Codex-3-sonnet`) work.
+
+### GET /api/v1/models/ (verified, role-aware)
+
+Returns models the caller can see (`List[ModelUserResponse]`).
+
+### GET /api/v1/models/base (admin)
+
+Foundation models registered with the hub.
+
+### POST /api/v1/models/create (verified, needs `workspace.models` perm)
+
+Body: `ModelForm`. Creates a model row.
+
+### POST /api/v1/models/model/toggle?id=... (verified)
+
+Flips `is_active` on the named model. Idempotent-ish.
+
+```bash
+curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/models/model/toggle?id=$MODEL_ID" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" | jq
+```
+
+### DELETE /api/v1/models/model/delete?id=... (verified)
+
+Removes one model.
+
+### DELETE /api/v1/models/delete/all (admin) — destructive, irreversible
+
+Purges every model row on the hub. Always confirm before issuing this.
+
+## Registry — `/api/v1/registry`
+
+Source: `front/backend/open_webui/routers/registry.py`. The registry is
+the **public marketplace** — separate from the local agents table. An
+agent can exist in `agent` (installed here) without being in
+`registry_agent`, and vice versa.
+
+- `GET /api/v1/registry/` — list cards visible to the caller.
+- `POST /api/v1/registry/` — submit by URL (form `SubmitRegistryAgentForm`).
+- `PATCH /api/v1/registry/{id}` — update a card.
+- `DELETE /api/v1/registry/{id}` — destructive; remove from marketplace.
+
+## Health
+
+These endpoints are mounted at the root, NOT under `/api/v1`:
+
+- `GET /health` → `{ "status": true }`. Public, no auth.
+- `GET /health/db` → DB connectivity check. Public.
+- `GET /api/version` → `{ "version": str }`. Public.
+
+```bash
+curl -fs "$OPENBEAVS_BASE_URL/health" >/dev/null \
+  && curl -fs "$OPENBEAVS_BASE_URL/health/db" >/dev/null \
+  && curl -fs "$OPENBEAVS_BASE_URL/api/version" \
+  || echo 'hub unhealthy'
+```
+
+## Common workflows
+
+### 1. List every agent, including inactive
+
+```bash
+curl -s "$OPENBEAVS_BASE_URL/api/v1/agents/all" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  | jq '.[] | {id,name,is_active,deployment_mode,deployment_status,model}'
+```
+
+### 2. Deploy an internal-mode agent and verify it's reachable
+
+```bash
+NEW=$(curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/agents/deploy" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"CloudBot","description":"demo","system_prompt":"answer briefly","provider":"anthropic"}')
+ID=$(echo "$NEW" | jq -r .id)
+echo "deployed $ID"
+curl -s "$OPENBEAVS_BASE_URL/api/v1/agents/$ID" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  | jq '{id,name,deployment_mode,deployment_status}'
+```
+
+For internal-mode agents, the hub also exposes the discovery card at
+`GET /api/v1/agents/{id}/internal-a2a/.well-known/agent.json` (public)
+which is useful for proving the in-process route is wired up.
+
+### 3. Promote a user to admin by email
+
+```bash
+ID=$(curl -s "$OPENBEAVS_BASE_URL/api/v1/users/?limit=200" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  | jq -r '.[] | select(.email == "kimminsu@oregonstate.edu") | .id')
+[ -n "$ID" ] || { echo "user not found"; exit 1; }
+curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/users/update/role" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg id "$ID" '{id:$id,role:"admin"}')" | jq
+```
+
+### 4. Mint a service-account bearer for CI
+
+```bash
+read -rsp 'password for new account: ' P && echo
+curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/auths/add" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg p "$P" '{name:"CI Bot",email:"ci-bot@example.com",password:$p,role:"user"}')" \
+  | jq -r .token
+unset P
+```
+
+The output is the bearer for the new account. It is the only copy.
+
+### 5. Health check the hub
+
+See the curl block in the Health section above. Wrap in CI as the smoke
+check after every deploy.
+
+## Safety rules
+
+Confirm with the user before running ANY of these:
+
+- `DELETE /api/v1/agents/{id}` — removes a deployed agent.
+- `DELETE /api/v1/users/{id}` — removes a user account.
+- `POST /api/v1/users/{user_id}/update` — overwrites name/email/password
+  in one call; easy to clobber data.
+- `DELETE /api/v1/models/delete/all` — purges every model row.
+- `DELETE /api/v1/registry/{id}` — removes a marketplace card.
+- `POST /api/v1/auths/add` — mints a token; the new token is the only
+  copy and must be handled like a secret.
+- `POST /api/v1/agents/deploy` against prod with `deploy_to_cloud_run:true`
+  — has shared-infra side effects and costs money.
+
+Reads (`GET`) and idempotent toggles do NOT need confirmation.
+
+## Routes intentionally NOT documented here
+
+These exist but are out of scope for admin operations — point the user
+at the routers if they ask:
+
+- `front/backend/open_webui/routers/chats.py` (chat history) — UI-driven.
+- `front/backend/open_webui/routers/files.py`, `knowledge.py` — multipart
+  uploads / RAG; awkward via curl.
+- `front/backend/open_webui/routers/ollama.py`, `openai.py` — LLM
+  proxies; the chat path uses these internally.
+- `tools.py`, `prompts.py`, `tasks.py`, `memories.py`, `folders.py`,
+  `groups.py`, `channels.py`, `functions.py`, `pipelines.py`,
+  `images.py`, `audio.py`, `retrieval.py`, `embed.py`, `tickets.py`,
+  `configs.py`, `utils.py` — all under `/api/v1/<name>`; survey those
+  files directly if you need them.
+
+## When this skill is wrong
+
+Routes drift. If a curl here returns 404 or 422, open the router file
+referenced in that section and trust the source. Then edit this skill
+to match — leaving stale docs is worse than no docs.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,23 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(docker info *)",
+      "Bash(docker build *)",
+      "Bash(tee /tmp/openbeavs-build.log)",
+      "Bash(docker run *)",
+      "Bash(tee /tmp/openbeavs-run.log)",
+      "Bash(curl -s -o /dev/null -w 'HTTP %{http_code} \\(%{size_download} bytes\\)\\\\n' http://localhost:8080/)",
+      "Bash(curl -s -w '\\\\nHTTP %{http_code}\\\\n' http://localhost:8080/health)",
+      "Bash(curl -s -o /dev/null -w 'HTTP %{http_code}\\\\n' http://localhost:8080/docs)",
+      "Bash(curl -s -w '\\\\nHTTP %{http_code}\\\\n' http://localhost:8080/.well-known/agent.json)",
+      "Bash(curl -s http://localhost:8080/openapi.json)",
+      "Bash(python3 -c \"import json,sys; d=json.load\\(sys.stdin\\); print\\(f'{len\\(d.get\\(\\\\\"paths\\\\\",{}\\)\\)} paths, title={d.get\\(\\\\\"info\\\\\",{}\\).get\\(\\\\\"title\\\\\"\\)}'\\)\")",
+      "Bash(python -m pytest backend/open_webui/test/security/ -v --collect-only)",
+      "Bash(python3 -c \"import pytest; print\\(pytest.__version__\\)\")",
+      "Bash(command -v docker)",
+      "Read(//usr/bin/**)",
+      "Bash(docker.exe ps *)",
+      "Bash(python3 *)"
+    ]
+  }
+}

--- a/.claude/skills/openbeavs-admin/SKILL.md
+++ b/.claude/skills/openbeavs-admin/SKILL.md
@@ -1,0 +1,559 @@
+---
+name: openbeavs-admin
+description: Operate a running OpenBeavs / GENESIS-AI-Hub instance over its REST API. USE THIS SKILL whenever the user asks to list agents, list users, list models, deploy an agent, register an A2A agent by URL, delete an agent, promote a user, mint a service-account bearer token, query the public registry, or health-check a hub — local or deployed. The skill documents the auth flow (POST /api/v1/auths/signin → bearer token), the trailing-slash quirk on collection endpoints (e.g. /api/v1/agents/ vs /api/v1/agents), the dev placeholder admin (admin@gmail.com / 1234), and the response shapes for the highest-traffic routes. Reads OPENBEAVS_BASE_URL and OPENBEAVS_ADMIN_TOKEN from the environment; if either is missing, ask the user before guessing.
+---
+
+# OpenBeavs admin skill
+
+This skill teaches you how to drive a running OpenBeavs hub using `curl`. The
+hub is a FastAPI service at `front/backend/open_webui/`; routers live under
+`front/backend/open_webui/routers/`. When something here looks wrong, the
+routers are the source of truth — open the file referenced in the section.
+
+## Prerequisites — token and base URL
+
+Before any request, both env vars must be set in the bash session:
+
+- `OPENBEAVS_BASE_URL` — e.g. `http://localhost:8080` for local dev, or
+  the Cloud Run URL of the active hub for prod.
+- `OPENBEAVS_ADMIN_TOKEN` — a bearer token belonging to an `admin` role
+  user. Either pull it from browser DevTools (`localStorage.token` after
+  signing in via the UI) or call the signin endpoint below.
+
+If either is missing, ask the user this exact question before doing
+anything else:
+
+> "I need `OPENBEAVS_BASE_URL` and `OPENBEAVS_ADMIN_TOKEN` to talk to the
+> hub. What's the base URL, and do you have an admin token already, or
+> would you like me to walk through `signin`?"
+
+Never invent a URL. Never paste a token into the conversation; the user
+should `export` it themselves. Treat the token like a password — do not
+echo it back, do not write it to disk, and remind the user to unset it
+when done (`unset OPENBEAVS_ADMIN_TOKEN`).
+
+### Default placeholder admin (dev/staging only)
+
+The deployed dev/staging hub seeds a placeholder admin account:
+
+- email: `admin@gmail.com`
+- password: `1234`
+
+**Use these only after the user confirms the hub is in dev/staging
+mode** — never assume them for prod. If the user has not confirmed,
+ask: "Is this hub using the placeholder `admin@gmail.com / 1234`
+admin, or do you have your own admin credentials?" Do NOT default to
+the email in `userEmail`/the harness context — that account almost
+certainly has no admin role on the hub.
+
+### Quick start — copy this exactly
+
+> **Note on env-var scope.** `!`-prefix lines in the Claude prompt and
+> Claude's own Bash tool calls each spawn a fresh subshell —
+> `export`s done in one subshell do NOT survive into later calls. So
+> if the user `!export`s the vars from inside Claude, those exports
+> are gone by the time Claude tries to run a curl.
+>
+> **How the skill should handle this:** if a Bash tool call shows
+> `OPENBEAVS_BASE_URL` empty or `OPENBEAVS_ADMIN_TOKEN` unset, just
+> silently re-auth in a single Bash call (sign in + use the token in
+> the same heredoc or `&&` chain). It's faster than asking the user
+> to exit and re-launch, and the placeholder dev creds are harmless.
+> Mention afterwards (one short line) that for persistence across
+> turns the user can `export` both in the terminal **before** running
+> `claude` — that way every subsequent Bash tool call inherits them
+> and you don't need to re-auth on every request.
+>
+> The exception: re-auth ONLY when the email/password are already
+> known (placeholder dev admin, or stored from earlier this session).
+> If neither var is set AND no creds are known, ask the user.
+
+The fastest way to get a working session, with the trailing slash
+already correct. The user can either run these in their terminal
+*before* `claude` (preferred — exports persist for the whole
+session), or paste the same block as one Bash call inside Claude
+(works for one turn):
+
+```bash
+# In your terminal, BEFORE running `claude`:
+export OPENBEAVS_BASE_URL="https://openbeavs-deploy-test-<hash>.us-west1.run.app"
+export OPENBEAVS_ADMIN_TOKEN=$(curl -s -X POST \
+  "$OPENBEAVS_BASE_URL/api/v1/auths/signin" \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@gmail.com","password":"1234"}' \
+  | jq -r .token)
+
+claude   # Claude inherits both vars in every Bash tool call
+```
+
+Once inside Claude, the very first thing the skill does is verify
+both vars are populated:
+
+```bash
+echo "URL: $OPENBEAVS_BASE_URL"
+echo "TOKEN set: $([ -n "$OPENBEAVS_ADMIN_TOKEN" ] && echo yes || echo no)"
+
+# Confirm the token works AND you got JSON back (not HTML):
+curl -fsS "$OPENBEAVS_BASE_URL/api/v1/auths/" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  | jq '{id,email,role}'
+
+# List local agents — note the TRAILING SLASH:
+curl -fsS "$OPENBEAVS_BASE_URL/api/v1/agents/" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" | jq
+```
+
+If the env-check shows either var empty and the placeholder dev
+creds apply, re-auth in-line in the same Bash call and proceed:
+
+```bash
+BASE="${OPENBEAVS_BASE_URL:-https://openbeavs-deploy-test-<hash>.us-west1.run.app}"
+TOKEN="${OPENBEAVS_ADMIN_TOKEN:-$(curl -s -X POST "$BASE/api/v1/auths/signin" \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@gmail.com","password":"1234"}' | jq -r .token)}"
+curl -fsS "$BASE/api/v1/agents/" -H "Authorization: Bearer $TOKEN" | jq
+```
+
+Use `curl -fsS` (fail-fast on HTTP errors) and pipe through `jq` so an
+HTML body fails loudly. If `jq` errors with "parse error", you almost
+certainly forgot the trailing slash on a collection endpoint.
+
+### Finding the prod URL
+
+The active prod service is `openbeavs-deploy-test` in project
+`osu-genesis-hub`, region `us-west1`. Other Cloud Run services
+(`openbeavs-main`, `genesis-ai-hub-backend`) are placeholders or stale
+deployments — `openbeavs-main` returns the SvelteKit shell with no
+backend wired, so any API call will look like it "works" (HTTP 200 +
+HTML) until you parse the body. **Always ask the user which hub** before
+hitting `gcloud run services list`; if you must list, only trust
+`openbeavs-deploy-test`.
+
+### CRITICAL — trailing-slash quirk
+
+Collection endpoints (the ones whose path ends at the router prefix)
+**require a trailing slash**:
+
+- ✅ `GET /api/v1/agents/` → JSON list from FastAPI
+- ❌ `GET /api/v1/agents`  → SvelteKit shell, HTTP 200, `text/html`
+
+This bites because the response is a 200, not a redirect or 404 — a
+no-slash request silently returns the frontend HTML. If a curl returns
+HTML where you expected JSON, the first thing to check is the trailing
+slash. The same pattern applies to `/api/v1/users/`, `/api/v1/models/`,
+`/api/v1/registry/`, `/api/v1/auths/`, and any other root-of-router GET.
+Sub-paths (`/api/v1/agents/all`, `/api/v1/agents/{id}`) do NOT need the
+trailing slash — only the collection root does.
+
+Always pipe JSON-expecting responses through `jq` (or `python3 -m
+json.tool`) so an accidental HTML body fails loudly instead of
+spreading downstream.
+
+## Auth surface — `/api/v1/auths`
+
+Source: `front/backend/open_webui/routers/auths.py`.
+
+### POST /api/v1/auths/signin (public)
+
+Body: `{ "email": str, "password": str }`.
+
+Response (`SigninResponse`) — fields:
+
+| Field               | Type        | Meaning                                                          |
+|---------------------|-------------|------------------------------------------------------------------|
+| `token`             | str (JWT)   | Bearer token. Pass as `Authorization: Bearer <token>`.           |
+| `token_type`        | str         | Always `"Bearer"`.                                               |
+| `expires_at`        | int \| null | Unix epoch seconds. Null when `JWT_EXPIRES_IN=-1` (no expiry).   |
+| `id`                | str         | User ID for the signed-in account.                               |
+| `email`             | str         | Lowercased email.                                                |
+| `name`              | str         | Display name.                                                    |
+| `role`              | str         | `"pending"`, `"user"`, or `"admin"` — verify this is `"admin"` before using the token for admin routes. |
+| `profile_image_url` | str         | Avatar URL.                                                      |
+| `permissions`       | dict        | Resolved permission map for the user's role + group membership.  |
+
+Errors:
+- `400 "The email or password provided is incorrect..."` — bad creds.
+- `403` — pending or disabled account.
+
+Have the user run this in their own terminal so the password never
+enters the chat:
+
+```bash
+read -rsp 'password: ' PASS && echo
+curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/auths/signin" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg e "$EMAIL" --arg p "$PASS" '{email:$e,password:$p}')" \
+  | jq -r .token
+unset PASS
+```
+
+### GET /api/v1/auths/ (verified user)
+
+Verify the current token works and inspect the caller's role:
+
+```bash
+curl -s "$OPENBEAVS_BASE_URL/api/v1/auths/" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  | jq '{id,email,role}'
+```
+
+### POST /api/v1/auths/add (admin only)
+
+Mints a new user **and returns a bearer token for that user** in the
+same response. Body matches `AddUserForm`:
+
+```
+{ "name": str, "email": str, "password": str,
+  "profile_image_url": str (optional, defaults to "/user.png"),
+  "role": "pending" | "user" | "admin" (optional, defaults to "pending") }
+```
+
+The returned `token` is the only copy. Print it once, warn the user it
+cannot be re-fetched, and do not store it anywhere.
+
+```bash
+curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/auths/add" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"CI Bot","email":"ci@example.com","password":"...","role":"user"}' \
+  | jq
+```
+
+## Agents — `/api/v1/agents`
+
+Source: `front/backend/open_webui/routers/agents.py`. An "agent" here is
+a row in the `agent` table representing an A2A endpoint installed on
+this hub. `deployment_mode` is one of: `internal` (served in-process by
+the hub itself), `cloud_run` (separate Cloud Run service), or absent
+(externally registered via URL).
+
+### GET /api/v1/agents/ (verified user)
+
+Returns active agents visible to the caller. Response: `List[AgentResponse]`.
+Note this is a *trimmed* shape — for the full agent record (provider, model,
+system_prompt, deployment_mode), use `/all` or `/{agent_id}`.
+
+Per-row fields:
+
+| Field          | Type                  | Meaning                                              |
+|----------------|-----------------------|------------------------------------------------------|
+| `id`           | str (uuid)            | Stable agent ID; use this in path params.            |
+| `name`         | str                   | Display name from the discovery card or deploy form. |
+| `description`  | str                   | Short description for the workspace card.            |
+| `endpoint`     | str \| null           | A2A JSON-RPC POST URL. `null` for URL-only registrations. |
+| `url`          | str \| null           | Base homepage URL. Always present; chat path falls back to `url` when `endpoint` is null. |
+| `capabilities` | dict \| null          | A2A capability flags, typically `{"streaming": bool}`. |
+| `skills`       | list[dict] \| null    | Discovery-card skills array.                         |
+| `is_active`    | bool                  | Soft-delete / disable flag.                          |
+
+```bash
+curl -fsS "$OPENBEAVS_BASE_URL/api/v1/agents/" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  | jq '.[] | {id,name,endpoint,url,is_active}'
+```
+
+### GET /api/v1/agents/all (admin)
+
+Includes inactive rows AND returns the full `AgentModel` shape — adds
+these fields on top of the trimmed list above:
+
+| Field               | Type           | Meaning                                                                                  |
+|---------------------|----------------|------------------------------------------------------------------------------------------|
+| `version`           | str \| null    | Discovery-card version, e.g. `"1.0.0"`.                                                  |
+| `default_input_modes`  | list[str]   | A2A input modalities; usually `["text"]`.                                                |
+| `default_output_modes` | list[str]   | A2A output modalities; usually `["text"]`.                                               |
+| `input_schema`      | dict \| null   | Optional JSON schema for input validation.                                               |
+| `output_schema`     | dict \| null   | Optional JSON schema for output validation.                                              |
+| `profile_image_url` | str \| null    | Avatar URL; `/static/favicon.png` is the default fallback.                               |
+| `system_prompt`     | str \| null    | Set only for agents created via `/deploy`. Null for URL-registered agents.               |
+| `provider`          | str \| null    | `"anthropic"`, `"openai"`, or `"gemini"` for deployed agents; null otherwise.            |
+| `model`             | str \| null    | Provider-specific model id (e.g. `"claude-sonnet-4-6"`).                                 |
+| `deployment_mode`   | str \| null    | `"internal"` (in-process), `"cloud_run"` (separate service), or null (externally registered). |
+| `deployment_status` | str \| null    | `"ready"` is the only state currently emitted by `/deploy`.                              |
+| `created_at`        | int            | Unix epoch seconds.                                                                      |
+| `updated_at`        | int            | Unix epoch seconds.                                                                      |
+| `user_id`           | str \| null    | Owner. Admins can see all rows; non-admins see only their own.                           |
+
+How to read `deployment_mode` quickly:
+
+- `null` → registered by URL via `/register-by-url`. The hub does not
+  host this agent; chat traffic goes to `endpoint || url`.
+- `"internal"` → the hub itself serves the agent in-process. The
+  `endpoint` will be `{base_url}/api/v1/agents/{id}/internal-a2a`. Chat
+  traffic short-circuits the HTTP round-trip via `utils/chat.py`.
+- `"cloud_run"` → a separate Cloud Run service was provisioned at
+  deploy time. `endpoint` is that service's URL.
+
+### GET /api/v1/agents/{agent_id} (verified)
+
+Returns one full `AgentModel` (same shape as `/all` rows). 404 if the
+ID does not exist; 401 if a non-admin requests an agent they don't
+own.
+
+### POST /api/v1/agents/register-by-url (verified)
+
+Fetches the target's `/.well-known/agent.json`, parses the discovery
+card, and inserts an agent row. Body: `RegisterAgentByUrlForm`:
+
+```
+{ "agent_url": str, "profile_image_url": str (optional) }
+```
+
+```bash
+curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/agents/register-by-url" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"agent_url":"https://weather.example.com"}' | jq
+```
+
+### POST /api/v1/agents/deploy (admin) — destructive on prod
+
+Creates a brand-new internally-hosted A2A agent. Body: `DeployAgentForm`:
+
+```
+{ "name": str, "description": str, "system_prompt": str,
+  "provider": "anthropic" | "openai" | "gemini" (default "anthropic"),
+  "model": str (optional; provider default applied if omitted),
+  "profile_image_url": str (optional),
+  "publish_to_registry": bool (default true),
+  "deploy_to_cloud_run": bool (default false) }
+```
+
+If `deploy_to_cloud_run` is true on prod, the hub gates this with
+`OPENBEAVS_CLOUD_RUN_DISABLED=1` and returns 503. For internal-mode
+deploys, the hub stores `endpoint = {base_url}/api/v1/agents/{id}/internal-a2a`
+and serves the agent in-process.
+
+```bash
+curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/agents/deploy" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name":"WeatherBot",
+    "description":"Answers Oregon weather questions",
+    "system_prompt":"You are a concise weather assistant.",
+    "provider":"anthropic"
+  }' | jq
+```
+
+### DELETE /api/v1/agents/{agent_id} (verified, owner-or-admin)
+
+```bash
+curl -s -X DELETE "$OPENBEAVS_BASE_URL/api/v1/agents/$AGENT_ID" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN"
+```
+
+## Users — `/api/v1/users`
+
+Source: `front/backend/open_webui/routers/users.py`.
+
+### GET /api/v1/users/ (admin)
+
+Pagination via `?skip=&limit=`. Returns `List[UserModel]`.
+
+Per-row fields:
+
+| Field               | Type        | Meaning                                                            |
+|---------------------|-------------|--------------------------------------------------------------------|
+| `id`                | str (uuid)  | Stable user ID; use in `/update/role` and `/{id}/update`.          |
+| `email`             | str         | Lowercased on insert. Login key.                                   |
+| `name`              | str         | Display name.                                                      |
+| `role`              | str         | `"pending"` (signup queued, no access), `"user"`, or `"admin"`.    |
+| `profile_image_url` | str         | Avatar URL; `/user.png` is the default fallback.                   |
+| `last_active_at`    | int \| null | Unix epoch seconds of last token verification.                     |
+| `created_at`        | int         | Unix epoch seconds.                                                |
+| `updated_at`        | int         | Unix epoch seconds.                                                |
+| `api_key`           | str \| null | Set if the user generated a personal API key via `/api/v1/auths/api_key`. |
+| `settings`          | dict \| null | Per-user UI preferences blob.                                     |
+| `info`              | dict \| null | Free-form admin notes.                                            |
+
+```bash
+curl -fsS "$OPENBEAVS_BASE_URL/api/v1/users/?limit=200" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  | jq '.[] | {id,email,role,last_active_at}'
+```
+
+`role == "pending"` is the most common gotcha — new signups are queued
+in this state until an admin promotes them via `/update/role`. They
+can sign in but can't read any resource.
+
+### POST /api/v1/users/update/role (admin)
+
+Body: `{ "id": str, "role": "pending" | "user" | "admin" }`. Note the
+hub refuses to demote the first-ever user (the bootstrap admin).
+
+```bash
+curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/users/update/role" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"<user-id>","role":"admin"}' | jq
+```
+
+### POST /api/v1/users/{user_id}/update (admin) — destructive
+
+Body: `UserUpdateForm = { name, email, profile_image_url, password? }`.
+Overwrites all four fields; pass current values for ones you don't want
+to change.
+
+### DELETE /api/v1/users/{user_id} (admin) — destructive
+
+## Models — `/api/v1/models`
+
+Source: `front/backend/open_webui/routers/models.py`. Note the per-model
+endpoints take `id` as a **query parameter**, not a path component, so
+slashes in IDs (`anthropic/claude-3-sonnet`) work.
+
+### GET /api/v1/models/ (verified, role-aware)
+
+Returns models the caller can see (`List[ModelUserResponse]`).
+
+### GET /api/v1/models/base (admin)
+
+Foundation models registered with the hub.
+
+### POST /api/v1/models/create (verified, needs `workspace.models` perm)
+
+Body: `ModelForm`. Creates a model row.
+
+### POST /api/v1/models/model/toggle?id=... (verified)
+
+Flips `is_active` on the named model. Idempotent-ish.
+
+```bash
+curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/models/model/toggle?id=$MODEL_ID" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" | jq
+```
+
+### DELETE /api/v1/models/model/delete?id=... (verified)
+
+Removes one model.
+
+### DELETE /api/v1/models/delete/all (admin) — destructive, irreversible
+
+Purges every model row on the hub. Always confirm before issuing this.
+
+## Registry — `/api/v1/registry`
+
+Source: `front/backend/open_webui/routers/registry.py`. The registry is
+the **public marketplace** — separate from the local agents table. An
+agent can exist in `agent` (installed here) without being in
+`registry_agent`, and vice versa.
+
+- `GET /api/v1/registry/` — list cards visible to the caller.
+- `POST /api/v1/registry/` — submit by URL (form `SubmitRegistryAgentForm`).
+- `PATCH /api/v1/registry/{id}` — update a card.
+- `DELETE /api/v1/registry/{id}` — destructive; remove from marketplace.
+
+## Health
+
+These endpoints are mounted at the root, NOT under `/api/v1`:
+
+- `GET /health` → `{ "status": true }`. Public, no auth.
+- `GET /health/db` → DB connectivity check. Public.
+- `GET /api/version` → `{ "version": str }`. Public.
+
+```bash
+curl -fs "$OPENBEAVS_BASE_URL/health" >/dev/null \
+  && curl -fs "$OPENBEAVS_BASE_URL/health/db" >/dev/null \
+  && curl -fs "$OPENBEAVS_BASE_URL/api/version" \
+  || echo 'hub unhealthy'
+```
+
+## Common workflows
+
+### 1. List every agent, including inactive
+
+```bash
+curl -s "$OPENBEAVS_BASE_URL/api/v1/agents/all" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  | jq '.[] | {id,name,is_active,deployment_mode,deployment_status,model}'
+```
+
+### 2. Deploy an internal-mode agent and verify it's reachable
+
+```bash
+NEW=$(curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/agents/deploy" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"CloudBot","description":"demo","system_prompt":"answer briefly","provider":"anthropic"}')
+ID=$(echo "$NEW" | jq -r .id)
+echo "deployed $ID"
+curl -s "$OPENBEAVS_BASE_URL/api/v1/agents/$ID" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  | jq '{id,name,deployment_mode,deployment_status}'
+```
+
+For internal-mode agents, the hub also exposes the discovery card at
+`GET /api/v1/agents/{id}/internal-a2a/.well-known/agent.json` (public)
+which is useful for proving the in-process route is wired up.
+
+### 3. Promote a user to admin by email
+
+```bash
+ID=$(curl -s "$OPENBEAVS_BASE_URL/api/v1/users/?limit=200" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  | jq -r '.[] | select(.email == "kimminsu@oregonstate.edu") | .id')
+[ -n "$ID" ] || { echo "user not found"; exit 1; }
+curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/users/update/role" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg id "$ID" '{id:$id,role:"admin"}')" | jq
+```
+
+### 4. Mint a service-account bearer for CI
+
+```bash
+read -rsp 'password for new account: ' P && echo
+curl -s -X POST "$OPENBEAVS_BASE_URL/api/v1/auths/add" \
+  -H "Authorization: Bearer $OPENBEAVS_ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "$(jq -nc --arg p "$P" '{name:"CI Bot",email:"ci-bot@example.com",password:$p,role:"user"}')" \
+  | jq -r .token
+unset P
+```
+
+The output is the bearer for the new account. It is the only copy.
+
+### 5. Health check the hub
+
+See the curl block in the Health section above. Wrap in CI as the smoke
+check after every deploy.
+
+## Safety rules
+
+Confirm with the user before running ANY of these:
+
+- `DELETE /api/v1/agents/{id}` — removes a deployed agent.
+- `DELETE /api/v1/users/{id}` — removes a user account.
+- `POST /api/v1/users/{user_id}/update` — overwrites name/email/password
+  in one call; easy to clobber data.
+- `DELETE /api/v1/models/delete/all` — purges every model row.
+- `DELETE /api/v1/registry/{id}` — removes a marketplace card.
+- `POST /api/v1/auths/add` — mints a token; the new token is the only
+  copy and must be handled like a secret.
+- `POST /api/v1/agents/deploy` against prod with `deploy_to_cloud_run:true`
+  — has shared-infra side effects and costs money.
+
+Reads (`GET`) and idempotent toggles do NOT need confirmation.
+
+## Routes intentionally NOT documented here
+
+These exist but are out of scope for admin operations — point the user
+at the routers if they ask:
+
+- `front/backend/open_webui/routers/chats.py` (chat history) — UI-driven.
+- `front/backend/open_webui/routers/files.py`, `knowledge.py` — multipart
+  uploads / RAG; awkward via curl.
+- `front/backend/open_webui/routers/ollama.py`, `openai.py` — LLM
+  proxies; the chat path uses these internally.
+- `tools.py`, `prompts.py`, `tasks.py`, `memories.py`, `folders.py`,
+  `groups.py`, `channels.py`, `functions.py`, `pipelines.py`,
+  `images.py`, `audio.py`, `retrieval.py`, `embed.py`, `tickets.py`,
+  `configs.py`, `utils.py` — all under `/api/v1/<name>`; survey those
+  files directly if you need them.
+
+## When this skill is wrong
+
+Routes drift. If a curl here returns 404 or 422, open the router file
+referenced in that section and trust the source. Then edit this skill
+to match — leaving stale docs is worse than no docs.

--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ ANTHROPIC_API_KEY=
 CHATGPT_API_KEY=
 GEMINI_CHAT_API_KEY=
 
+# Dedicated Cloud Run agent deployments keep one warm instance by default.
+# Set to 0 to allow scale-to-zero for lower cost.
+OPENBEAVS_AGENT_MIN_INSTANCES=1
+
 # Microsoft SSO (optional)
 MICROSOFT_CLIENT_ID=
 MICROSOFT_CLIENT_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,12 @@ GEMINI_CHAT_API_KEY=
 # Dedicated Cloud Run agent deployments keep one warm instance by default.
 # Set to 0 to allow scale-to-zero for lower cost.
 OPENBEAVS_AGENT_MIN_INSTANCES=1
+# Optional for private dedicated Cloud Run agents when the hub uses a custom runtime SA.
+OPENBEAVS_HUB_SERVICE_ACCOUNT=
+
+# Agent metadata refresh scheduler
+ENABLE_AGENT_REFRESH_SCHEDULER=True
+AGENT_REFRESH_INTERVAL_MINUTES=60
 
 # Microsoft SSO (optional)
 MICROSOFT_CLIENT_ID=

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Normalize line endings: store as LF in the repo and check out as LF
+# everywhere. Prevents CRLF churn from Windows/WSL working trees.
+* text=auto eol=lf
+
+# Treat known binary types as binary (never apply EOL conversion).
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.webp binary
+*.woff  binary
+*.woff2 binary
+*.ttf  binary
+*.eot  binary
+*.pdf  binary
+*.gz   binary
+*.zip  binary
+*.wasm binary

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,3 @@ __pycache__/
 *.py[cod]
 *$py.class
 *.so
-
-# Claude
-.claude/

--- a/agents/deploy_agent.py
+++ b/agents/deploy_agent.py
@@ -85,6 +85,7 @@ def deploy_agent_to_cloud_run(
     project: Optional[str] = None,
     region: Optional[str] = None,
     memory: str = "1Gi",
+    min_instances: int = 1,
     allow_unauthenticated: bool = True,
     secret_refs: Optional[Mapping[str, str]] = None,
     extra_set_env_vars: Optional[Iterable[str]] = None,
@@ -119,6 +120,9 @@ def deploy_agent_to_cloud_run(
     if not source_dir.exists():
         raise CloudRunDeployError(f"Agent source directory not found: {source_dir}")
 
+    if min_instances < 0:
+        raise CloudRunDeployError("min_instances must be greater than or equal to 0.")
+
     set_env_pairs = [f"{k}={v}" for k, v in env_vars.items()]
     set_env_pairs.append(f"APP_URL={app_url}")
     set_env_pairs.append(f"HOST_OVERRIDE={app_url}")
@@ -135,6 +139,7 @@ def deploy_agent_to_cloud_run(
         f"--region={region}",
         f"--project={project}",
         f"--memory={memory}",
+        f"--min-instances={min_instances}",
         f"--set-env-vars={','.join(set_env_pairs)}",
     ]
 
@@ -190,6 +195,15 @@ Examples:
         help="Make the service public (default: requires authentication)",
     )
     parser.add_argument("--memory", default="1Gi", help="Memory allocation (default: 1Gi)")
+    parser.add_argument(
+        "--min-instances",
+        type=int,
+        default=1,
+        help=(
+            "Minimum warm Cloud Run instances to keep "
+            "(default: 1; use 0 to allow scale-to-zero)"
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -223,6 +237,7 @@ Examples:
     print(f"Project:        {project}")
     print(f"Region:         {region}")
     print(f"Memory:         {args.memory}")
+    print(f"Min Instances:  {args.min_instances}")
     print(f"Authentication: {'Public' if args.allow_unauthenticated else 'IAM Required'}")
     print(f"Source:         {agent_dir}")
     print(f"{'='*70}\n")
@@ -241,6 +256,7 @@ Examples:
             project=project,
             region=region,
             memory=args.memory,
+            min_instances=args.min_instances,
             allow_unauthenticated=args.allow_unauthenticated,
         )
     except CloudRunDeployError as exc:

--- a/agents/deploy_agent.py
+++ b/agents/deploy_agent.py
@@ -77,6 +77,53 @@ def get_project_number(project_id: str) -> Optional[str]:
         return None
 
 
+def default_invoker_members(project_id: str) -> list[str]:
+    """Return default invoker members for private Cloud Run services."""
+    project_number = get_project_number(project_id)
+    if not project_number:
+        return []
+    return [f"serviceAccount:{project_number}-compute@developer.gserviceaccount.com"]
+
+
+def grant_cloud_run_invoker(
+    service_name: str,
+    *,
+    project: str,
+    region: str,
+    members: Iterable[str],
+) -> None:
+    """Grant Cloud Run invoker to each member."""
+    for member in members:
+        bind_cmd = [
+            "gcloud",
+            "run",
+            "services",
+            "add-iam-policy-binding",
+            service_name,
+            f"--member={member}",
+            "--role=roles/run.invoker",
+            f"--region={region}",
+            f"--project={project}",
+        ]
+        try:
+            result = subprocess.run(
+                bind_cmd,
+                shell=_use_shell(),
+                text=True,
+                encoding="utf-8",
+            )
+        except FileNotFoundError as exc:
+            raise CloudRunDeployError(
+                "gcloud is not installed or not on PATH on the hub host."
+            ) from exc
+
+        if result.returncode != 0:
+            raise CloudRunDeployError(
+                "Failed to grant roles/run.invoker on service "
+                f"'{service_name}' to '{member}' (exit {result.returncode})."
+            )
+
+
 def deploy_agent_to_cloud_run(
     service_name: str,
     source_dir: Path,
@@ -87,6 +134,7 @@ def deploy_agent_to_cloud_run(
     memory: str = "1Gi",
     min_instances: int = 1,
     allow_unauthenticated: bool = True,
+    invoker_members: Optional[Iterable[str]] = None,
     secret_refs: Optional[Mapping[str, str]] = None,
     extra_set_env_vars: Optional[Iterable[str]] = None,
 ) -> str:
@@ -169,6 +217,21 @@ def deploy_agent_to_cloud_run(
             f"gcloud run deploy failed for service '{service_name}' (exit {result.returncode})."
         )
 
+    if not allow_unauthenticated:
+        members = list(invoker_members or default_invoker_members(project))
+        if not members:
+            raise CloudRunDeployError(
+                "Private Cloud Run deploy requested, but no invoker service "
+                "account could be inferred. Pass invoker_members or set "
+                "OPENBEAVS_HUB_SERVICE_ACCOUNT."
+            )
+        grant_cloud_run_invoker(
+            service_name,
+            project=project,
+            region=region,
+            members=members,
+        )
+
     return app_url
 
 
@@ -193,6 +256,15 @@ Examples:
         "--allow-unauthenticated",
         action="store_true",
         help="Make the service public (default: requires authentication)",
+    )
+    parser.add_argument(
+        "--invoker-member",
+        action="append",
+        default=[],
+        help=(
+            "IAM member granted roles/run.invoker for private services. "
+            "Can be provided multiple times."
+        ),
     )
     parser.add_argument("--memory", default="1Gi", help="Memory allocation (default: 1Gi)")
     parser.add_argument(
@@ -258,6 +330,7 @@ Examples:
             memory=args.memory,
             min_instances=args.min_instances,
             allow_unauthenticated=args.allow_unauthenticated,
+            invoker_members=args.invoker_member or None,
         )
     except CloudRunDeployError as exc:
         print(f"\n{'='*70}")

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -48,6 +48,7 @@ steps:
       - '--execution-environment=gen2'
       - '--memory=8Gi'
       - '--cpu=4'
+      - '--min-instances=1'
       - '--port=8080'
       - '--timeout=600'
       - '--set-env-vars=HOST=0.0.0.0,WEBUI_SECRET_KEY=change-me-in-prod,OFFLINE_MODE=true,ENV=prod,RAG_EMBEDDING_MODEL_AUTO_UPDATE=false,RAG_RERANKING_MODEL_AUTO_UPDATE=false,BYPASS_EMBEDDING_AND_RETRIEVAL=true,BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL=true,WHISPER_MODEL_AUTO_UPDATE=false,OPENBEAVS_CLOUD_RUN_DISABLED=1'

--- a/deploy.sh
+++ b/deploy.sh
@@ -53,6 +53,7 @@ gcloud run deploy $BACKEND_SERVICE_NAME \
   --platform managed \
   --region $GCP_REGION \
   --project $GCP_PROJECT_ID \
+  --min-instances 1 \
   --allow-unauthenticated
 
 # Get the backend URL
@@ -77,6 +78,7 @@ gcloud run deploy $FRONTEND_SERVICE_NAME \
   --platform managed \
   --region $GCP_REGION \
   --project $GCP_PROJECT_ID \
+  --min-instances 1 \
   --allow-unauthenticated
 
 echo "Frontend deployed!"

--- a/docs/how-to-use-claude-skill.txt
+++ b/docs/how-to-use-claude-skill.txt
@@ -1,0 +1,36 @@
+How to use the skill
+
+  1. One-time setup per shell session. Export the two env vars before launching Claude Code (or run them in the Claude session via ! prefix):
+
+  export OPENBEAVS_BASE_URL="current-url-that-googlecloud-deploy-in"
+
+  export OPENBEAVS_ADMIN_TOKEN=$(curl -s -X POST \
+    "$OPENBEAVS_BASE_URL/api/v1/auths/signin" \
+    -H 'Content-Type: application/json' \
+    -d '{"email":"admin@gmail.com","password":"1234"}' | jq -r .token)
+  # That is the default login for admin, replace if you want to.
+
+  2. Then just ask in plain English. Claude Code matches your prompt against the skill's description and auto-loads SKILL.md when it sees triggers like:
+
+  - "list every agent on the deployed hub"
+  - "deploy an agent named WeatherBot with this system prompt..."
+  - "promote kimminsu@oregonstate.edu to admin"
+  - "mint a CI bearer token"
+  - "delete agent "
+  - "health-check the hub"
+  - "register https://my-agent.example.com as an A2A agent"
+
+  No slash command, no /skill invocation needed — the description has explicit trigger phrases the harness will match.
+
+  3. If Claude doesn't seem to use the skill, nudge it directly: "use the openbeavs-admin skill to list every agent." That forces Claude to read SKILL.md before acting.
+
+  4. Sanity-check the load. Once invoked, Claude should reference the trailing-slash rule, ask for the env vars if unset, and follow the safety-confirmation rules (e.g. confirming before DELETE
+  /api/v1/models/delete/all). If you see Claude curl-probing without referencing the skill, it didn't load — re-invoke explicitly.
+
+  5. Editing the skill. It's just markdown. Edit .claude/skills/openbeavs-admin/SKILL.md directly when routes change or new operations need documenting. The first ~50 lines (frontmatter + Quick Start) are the
+  highest-leverage — that's what Claude reads when scanning whether the skill applies.
+
+  6. Cleanup after a session. unset OPENBEAVS_ADMIN_TOKEN to evict the bearer from your shell history/env. The skill will refuse to run without it on the next session, so you'll be re-prompted.
+
+  7. To share with the team. The skill lives under .claude/skills/ in the repo — committing it on a topic branch and merging makes every teammate's Claude Code session pick it up automatically when they cd
+  into the repo. No per-machine install.

--- a/front/.env.example
+++ b/front/.env.example
@@ -14,6 +14,10 @@ ENABLE_CHATGPT_API='True'
 GEMINI_CHAT_API_KEY=''
 ENABLE_GEMINI_CHAT_API='True'
 
+# Dedicated Cloud Run agent deployments keep one warm instance by default.
+# Set to 0 to allow scale-to-zero for lower cost.
+OPENBEAVS_AGENT_MIN_INSTANCES='1'
+
 # AUTOMATIC1111_BASE_URL="http://localhost:7860"
 
 # DO NOT TRACK
@@ -34,4 +38,3 @@ DEFAULT_USER_ROLE='user'
 
 
 ENABLE_SIGNUP='True'
-

--- a/front/.env.example
+++ b/front/.env.example
@@ -17,6 +17,12 @@ ENABLE_GEMINI_CHAT_API='True'
 # Dedicated Cloud Run agent deployments keep one warm instance by default.
 # Set to 0 to allow scale-to-zero for lower cost.
 OPENBEAVS_AGENT_MIN_INSTANCES='1'
+# Optional for private dedicated Cloud Run agents when the hub uses a custom runtime SA.
+OPENBEAVS_HUB_SERVICE_ACCOUNT=''
+
+# Agent metadata refresh scheduler
+ENABLE_AGENT_REFRESH_SCHEDULER='True'
+AGENT_REFRESH_INTERVAL_MINUTES='60'
 
 # AUTOMATIC1111_BASE_URL="http://localhost:7860"
 

--- a/front/backend/open_webui/config.py
+++ b/front/backend/open_webui/config.py
@@ -803,6 +803,18 @@ A2A_AGENT_CONNECTIONS = PersistentConfig(
     [],
 )
 
+ENABLE_AGENT_REFRESH_SCHEDULER = PersistentConfig(
+    "ENABLE_AGENT_REFRESH_SCHEDULER",
+    "a2a.refresh.scheduler.enable",
+    os.environ.get("ENABLE_AGENT_REFRESH_SCHEDULER", "True").lower() == "true",
+)
+
+AGENT_REFRESH_INTERVAL_MINUTES = PersistentConfig(
+    "AGENT_REFRESH_INTERVAL_MINUTES",
+    "a2a.refresh.interval_minutes",
+    int(os.environ.get("AGENT_REFRESH_INTERVAL_MINUTES", "60")),
+)
+
 ####################################
 # OLLAMA_BASE_URL
 ####################################

--- a/front/backend/open_webui/internal/migrations/024_add_agent_visibility_fields.py
+++ b/front/backend/open_webui/internal/migrations/024_add_agent_visibility_fields.py
@@ -1,0 +1,34 @@
+"""Peewee migrations -- 024_add_agent_visibility_fields.py.
+
+Add in-app access control and Cloud Run auth metadata to A2A agents.
+"""
+
+from contextlib import suppress
+
+import peewee as pw
+from peewee_migrate import Migrator
+
+
+with suppress(ImportError):
+    import playhouse.postgres_ext as pw_pext
+
+
+def migrate(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Add visibility fields to agent rows."""
+
+    migrator.add_fields(
+        "agent",
+        access_control=pw.TextField(null=True),
+        cloud_run_auth_required=pw.BooleanField(default=False),
+    )
+    migrator.sql("UPDATE agent SET access_control = '{}' WHERE access_control IS NULL")
+
+
+def rollback(migrator: Migrator, database: pw.Database, *, fake=False):
+    """Remove visibility fields from agent rows."""
+
+    migrator.remove_fields(
+        "agent",
+        "access_control",
+        "cloud_run_auth_required",
+    )

--- a/front/backend/open_webui/main.py
+++ b/front/backend/open_webui/main.py
@@ -14,6 +14,7 @@ from contextlib import asynccontextmanager
 from urllib.parse import urlencode, parse_qs, urlparse
 from pydantic import BaseModel
 from sqlalchemy import text
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from typing import Optional
 from aiocache import cached
@@ -113,6 +114,8 @@ from open_webui.config import (
     # A2A Agent Connections
     ENABLE_A2A_AGENTS,
     A2A_AGENT_CONNECTIONS,
+    ENABLE_AGENT_REFRESH_SCHEDULER,
+    AGENT_REFRESH_INTERVAL_MINUTES,
     # Tool Server Configs
     TOOL_SERVER_CONNECTIONS,
     # Code Execution
@@ -386,6 +389,7 @@ from open_webui.tasks import (
     stop_task,
     list_tasks,
 )  # Import from tasks.py
+from open_webui.utils.agent_refresh import refresh_all_agent_metadata
 
 from open_webui.utils.redis import get_sentinels_from_env
 
@@ -397,6 +401,42 @@ if SAFE_MODE:
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MAIN"])
+
+
+async def run_agent_refresh_job():
+    """Run the scheduled agent metadata refresh job."""
+    try:
+        results = await asyncio.to_thread(refresh_all_agent_metadata)
+        success_count = len([result for result in results if result.success])
+        log.info(
+            "Agent metadata refresh completed: %s/%s succeeded",
+            success_count,
+            len(results),
+        )
+    except Exception:
+        log.exception("Agent metadata refresh job failed")
+
+
+def create_agent_refresh_scheduler(app: FastAPI) -> Optional[AsyncIOScheduler]:
+    """Create the in-process scheduler for agent metadata refresh."""
+    enabled = getattr(app.state.config, "ENABLE_AGENT_REFRESH_SCHEDULER", True)
+    interval_minutes = getattr(
+        app.state.config, "AGENT_REFRESH_INTERVAL_MINUTES", 60
+    )
+    if not enabled or interval_minutes <= 0:
+        return None
+
+    scheduler = AsyncIOScheduler(timezone="UTC")
+    scheduler.add_job(
+        run_agent_refresh_job,
+        "interval",
+        minutes=interval_minutes,
+        id="agent_metadata_refresh",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+    )
+    return scheduler
 
 
 class SPAStaticFiles(StaticFiles):
@@ -440,8 +480,17 @@ async def lifespan(app: FastAPI):
     if LICENSE_KEY:
         get_license_data(app, LICENSE_KEY)
 
+    agent_refresh_scheduler = create_agent_refresh_scheduler(app)
+    if agent_refresh_scheduler:
+        agent_refresh_scheduler.start()
+        app.state.AGENT_REFRESH_SCHEDULER = agent_refresh_scheduler
+
     asyncio.create_task(periodic_usage_pool_cleanup())
-    yield
+    try:
+        yield
+    finally:
+        if agent_refresh_scheduler and agent_refresh_scheduler.running:
+            agent_refresh_scheduler.shutdown(wait=False)
 
 
 app = FastAPI(
@@ -526,6 +575,8 @@ app.state.config.ENABLE_DIRECT_CONNECTIONS = ENABLE_DIRECT_CONNECTIONS
 
 app.state.config.ENABLE_A2A_AGENTS = ENABLE_A2A_AGENTS
 app.state.config.A2A_AGENT_CONNECTIONS = A2A_AGENT_CONNECTIONS
+app.state.config.ENABLE_AGENT_REFRESH_SCHEDULER = ENABLE_AGENT_REFRESH_SCHEDULER
+app.state.config.AGENT_REFRESH_INTERVAL_MINUTES = AGENT_REFRESH_INTERVAL_MINUTES
 
 app.include_router(registry.router, prefix="/api/v1/registry", tags=["registry"])
 app.include_router(tickets.router, prefix="/api/v1", tags=["tickets"])
@@ -1019,9 +1070,18 @@ async def get_models(request: Request, user=Depends(get_verified_user)):
     def get_filtered_models(models, user):
         filtered_models = []
         for model in models:
-            # Skip filtering for agent models - they're always accessible if enabled
             if model.get("owned_by") == "a2a-agent":
-                filtered_models.append(model)
+                agent = model.get("agent", {})
+                if (
+                    user.role == "admin"
+                    or agent.get("user_id") == user.id
+                    or has_access(
+                        user.id,
+                        type="read",
+                        access_control=agent.get("access_control"),
+                    )
+                ):
+                    filtered_models.append(model)
                 continue
 
             if model.get("arena"):
@@ -1074,8 +1134,11 @@ async def get_models(request: Request, user=Depends(get_verified_user)):
     if enable_a2a:
         try:
             agents = Agents.get_agents()
+            existing_model_ids = {model.get("id") for model in models}
             for agent in agents:
                 model_id = f"agent:{agent.id}"
+                if model_id in existing_model_ids:
+                    continue
                 agent_model = {
                     "id": model_id,
                     "name": agent.name,
@@ -1088,11 +1151,16 @@ async def get_models(request: Request, user=Depends(get_verified_user)):
                         "endpoint": agent.endpoint or agent.url,
                         "capabilities": agent.capabilities,
                         "skills": agent.skills,
+                        "access_control": agent.access_control,
+                        "user_id": agent.user_id,
+                        "cloud_run_auth_required": agent.cloud_run_auth_required,
                     },
                     "info": {
                         "meta": {
                             "description": agent.description,
                             "capabilities": agent.capabilities,
+                            "profile_image_url": agent.profile_image_url,
+                            "access_control": agent.access_control,
                         }
                     },
                     "tags": [{"name": "agent"}, {"name": "a2a"}]

--- a/front/backend/open_webui/models/agents.py
+++ b/front/backend/open_webui/models/agents.py
@@ -1,9 +1,11 @@
 import time
-from typing import Optional, List
-from pydantic import BaseModel, ConfigDict
+from typing import Any, Optional, List
+
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import BigInteger, Column, String, Text, Boolean
 
 from open_webui.internal.db import Base, JSONField, get_db
+from open_webui.utils.access_control import has_access
 
 ####################
 # Agent DB Schema
@@ -37,6 +39,13 @@ class Agent(Base):
     model = Column(String, nullable=True)
     deployment_mode = Column(String, nullable=True)
     deployment_status = Column(String, nullable=True)
+    cloud_run_auth_required = Column(Boolean, default=False)
+
+    # Access control
+    access_control = Column(JSONField, nullable=True)
+    # - `None`: public to all authenticated users
+    # - `{}`: private to owner/admin only
+    # - Custom permissions: {"read": {...}, "write": {...}}
 
     # Metadata
     is_active = Column(Boolean, default=True)
@@ -66,6 +75,8 @@ class AgentModel(BaseModel):
     model: Optional[str] = None
     deployment_mode: Optional[str] = None
     deployment_status: Optional[str] = None
+    cloud_run_auth_required: bool = False
+    access_control: Optional[dict] = None
     is_active: bool = True
     created_at: int
     updated_at: int
@@ -86,6 +97,14 @@ class AgentResponse(BaseModel):
     url: Optional[str] = None
     capabilities: Optional[dict] = None
     skills: Optional[List[dict]] = None
+    profile_image_url: Optional[str] = None
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    deployment_mode: Optional[str] = None
+    deployment_status: Optional[str] = None
+    cloud_run_auth_required: bool = False
+    access_control: Optional[dict] = None
+    user_id: Optional[str] = None
     is_active: bool = True
 
 
@@ -95,17 +114,20 @@ class RegisterAgentForm(BaseModel):
     endpoint: Optional[str] = None
     input_schema: Optional[dict] = None
     output_schema: Optional[dict] = None
+    access_control: Optional[dict] = Field(default_factory=dict)
 
 
 class RegisterAgentByUrlForm(BaseModel):
     agent_url: str
     profile_image_url: Optional[str] = None
+    access_control: Optional[dict] = Field(default_factory=dict)
 
 
 class AgentUpdateForm(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     endpoint: Optional[str] = None
+    access_control: Optional[dict] = None
     is_active: Optional[bool] = None
 
 
@@ -116,8 +138,10 @@ class DeployAgentForm(BaseModel):
     provider: str = "anthropic"
     model: Optional[str] = None
     profile_image_url: Optional[str] = None
-    publish_to_registry: bool = True
+    access_control: Optional[dict] = Field(default_factory=dict)
+    publish_to_registry: bool = False
     deploy_to_cloud_run: bool = False
+    cloud_run_public: bool = False
 
     model_config = ConfigDict(protected_namespaces=())
 
@@ -125,6 +149,9 @@ class DeployAgentForm(BaseModel):
 ####################
 # Agent Table
 ####################
+
+
+_UNSET = object()
 
 
 class AgentsTable:
@@ -148,8 +175,12 @@ class AgentsTable:
         model: Optional[str] = None,
         deployment_mode: Optional[str] = None,
         deployment_status: Optional[str] = None,
+        cloud_run_auth_required: bool = False,
+        access_control: Any = _UNSET,
         user_id: Optional[str] = None,
     ) -> Optional[AgentModel]:
+        """Insert a new A2A agent row."""
+        resolved_access_control = {} if access_control is _UNSET else access_control
         with get_db() as db:
             agent = AgentModel(
                 **{
@@ -171,6 +202,8 @@ class AgentsTable:
                     "model": model,
                     "deployment_mode": deployment_mode,
                     "deployment_status": deployment_status,
+                    "cloud_run_auth_required": cloud_run_auth_required,
+                    "access_control": resolved_access_control,
                     "is_active": True,
                     "created_at": int(time.time()),
                     "updated_at": int(time.time()),
@@ -185,6 +218,7 @@ class AgentsTable:
             return AgentModel.model_validate(result) if result else None
 
     def get_agent_by_id(self, id: str) -> Optional[AgentModel]:
+        """Return an agent by ID."""
         try:
             with get_db() as db:
                 agent = db.query(Agent).filter_by(id=id).first()
@@ -193,6 +227,7 @@ class AgentsTable:
             return None
 
     def get_agent_by_url(self, url: str) -> Optional[AgentModel]:
+        """Return an agent by public URL."""
         try:
             with get_db() as db:
                 agent = db.query(Agent).filter_by(url=url).first()
@@ -201,11 +236,24 @@ class AgentsTable:
             return None
 
     def get_agents(self) -> List[AgentModel]:
+        """Return all active agents."""
         with get_db() as db:
             agents = db.query(Agent).filter_by(is_active=True).all()
             return [AgentModel.model_validate(agent) for agent in agents]
 
+    def get_agents_by_user_id(
+        self, user_id: str, permission: str = "read"
+    ) -> List[AgentModel]:
+        """Return active agents visible to a user."""
+        return [
+            agent
+            for agent in self.get_agents()
+            if agent.user_id == user_id
+            or has_access(user_id, permission, agent.access_control)
+        ]
+
     def get_all_agents(self) -> List[AgentModel]:
+        """Return all agents regardless of active state."""
         with get_db() as db:
             agents = db.query(Agent).all()
             return [AgentModel.model_validate(agent) for agent in agents]
@@ -213,6 +261,7 @@ class AgentsTable:
     def update_agent_by_id(
         self, id: str, updated: AgentUpdateForm
     ) -> Optional[AgentModel]:
+        """Update mutable agent fields by ID."""
         try:
             with get_db() as db:
                 agent = db.query(Agent).filter_by(id=id).first()
@@ -232,6 +281,7 @@ class AgentsTable:
             return None
 
     def delete_agent_by_id(self, id: str) -> bool:
+        """Delete an agent by ID."""
         try:
             with get_db() as db:
                 agent = db.query(Agent).filter_by(id=id).first()
@@ -242,6 +292,42 @@ class AgentsTable:
                 return True
         except Exception:
             return False
+
+    def update_agent_metadata_by_id(
+        self, id: str, updated: dict
+    ) -> Optional[AgentModel]:
+        """Update A2A card-derived metadata for an agent."""
+        try:
+            with get_db() as db:
+                agent = db.query(Agent).filter_by(id=id).first()
+                if not agent:
+                    return None
+
+                allowed_keys = {
+                    "name",
+                    "description",
+                    "version",
+                    "capabilities",
+                    "skills",
+                    "default_input_modes",
+                    "default_output_modes",
+                    "profile_image_url",
+                }
+                update_data = {
+                    key: value
+                    for key, value in updated.items()
+                    if key in allowed_keys
+                }
+                update_data["updated_at"] = int(time.time())
+
+                for key, value in update_data.items():
+                    setattr(agent, key, value)
+
+                db.commit()
+                db.refresh(agent)
+                return AgentModel.model_validate(agent)
+        except Exception:
+            return None
 
 
 Agents = AgentsTable()

--- a/front/backend/open_webui/routers/agents.py
+++ b/front/backend/open_webui/routers/agents.py
@@ -1,11 +1,8 @@
 import uuid
-import json
 from typing import Optional, List, Dict, Any
-from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, status, Request
 from pydantic import BaseModel
-import requests
 
 from open_webui.models.agents import (
     AgentModel,
@@ -19,7 +16,18 @@ from open_webui.models.agents import (
 from open_webui.models.registry import RegistryAgents
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.access_control import has_access
+from open_webui.utils.a2a import (
+    fetch_agent_card,
+    normalize_agent_base_url,
+    post_jsonrpc_to_agent,
+)
 from open_webui.utils.a2a_runtime import PROVIDER_DEFAULTS, run_agent_turn
+from open_webui.utils.agent_refresh import (
+    AgentRefreshResult,
+    refresh_agent_metadata,
+    refresh_all_agent_metadata,
+)
 
 router = APIRouter()
 
@@ -58,6 +66,55 @@ class SendMessageToAgentForm(BaseModel):
     chat_id: Optional[str] = None
 
 
+def _can_read_agent(user, agent: AgentModel) -> bool:
+    """Return whether a user can read/use an agent."""
+    return (
+        user.role == "admin"
+        or agent.user_id == user.id
+        or has_access(user.id, "read", agent.access_control)
+    )
+
+
+def _can_write_agent(user, agent: AgentModel) -> bool:
+    """Return whether a user can mutate an agent."""
+    return (
+        user.role == "admin"
+        or agent.user_id == user.id
+        or has_access(user.id, "write", agent.access_control)
+    )
+
+
+def _agent_model_payload(agent: AgentModel) -> dict[str, Any]:
+    """Return an agent formatted as an OpenAI-style model."""
+    return {
+        "id": f"agent:{agent.id}",
+        "name": agent.name,
+        "object": "model",
+        "created": agent.created_at,
+        "owned_by": "a2a-agent",
+        "agent": {
+            "id": agent.id,
+            "description": agent.description,
+            "endpoint": agent.endpoint or agent.url,
+            "capabilities": agent.capabilities,
+            "skills": agent.skills,
+            "access_control": agent.access_control,
+            "user_id": agent.user_id,
+            "cloud_run_auth_required": agent.cloud_run_auth_required,
+        },
+        "info": {
+            "meta": {
+                "description": agent.description,
+                "capabilities": agent.capabilities,
+                "profile_image_url": agent.profile_image_url,
+                "access_control": agent.access_control,
+            }
+        },
+        "tags": [{"name": "agent"}, {"name": "a2a"}],
+        "actions": [],
+    }
+
+
 ############################
 # GetAgents
 ############################
@@ -66,7 +123,11 @@ class SendMessageToAgentForm(BaseModel):
 @router.get("/", response_model=List[AgentResponse])
 async def get_agents(user=Depends(get_verified_user)):
     """Get all active agents"""
-    agents = Agents.get_agents()
+    agents = (
+        Agents.get_agents()
+        if user.role == "admin"
+        else Agents.get_agents_by_user_id(user.id, permission="read")
+    )
     return [AgentResponse(**agent.model_dump()) for agent in agents]
 
 
@@ -75,23 +136,6 @@ async def get_all_agents(user=Depends(get_admin_user)):
     """Get all agents including inactive (admin only)"""
     agents = Agents.get_all_agents()
     return agents
-
-
-############################
-# GetAgentById
-############################
-
-
-@router.get("/{agent_id}", response_model=AgentModel)
-async def get_agent_by_id(agent_id: str, user=Depends(get_verified_user)):
-    """Get a specific agent by ID"""
-    agent = Agents.get_agent_by_id(agent_id)
-    if not agent:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ERROR_MESSAGES.NOT_FOUND,
-        )
-    return agent
 
 
 ############################
@@ -113,6 +157,7 @@ async def register_agent(
         endpoint=form_data.endpoint,
         input_schema=form_data.input_schema,
         output_schema=form_data.output_schema,
+        access_control=form_data.access_control,
         user_id=user.id,
     )
 
@@ -143,19 +188,9 @@ async def register_agent_by_url(
             detail="Agent URL is required",
         )
 
-    # Ensure the URL has proper scheme
-    if not agent_url.startswith(("http://", "https://")):
-        agent_url = "https://" + agent_url
-
-    # Parse the URL and normalize it to just the domain for the well-known file
-    parsed_url = urlparse(agent_url)
-    base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
-    well_known_url = f"{base_url}/.well-known/agent.json"
-
     try:
-        response = requests.get(well_known_url, timeout=10)
-        response.raise_for_status()
-        agent_data = response.json()
+        base_url = normalize_agent_base_url(agent_url)
+        agent_data = fetch_agent_card(base_url)
 
         # Extract information from well-known format
         name = agent_data.get("name", "Unknown Agent")
@@ -168,7 +203,11 @@ async def register_agent_by_url(
         default_output_modes = agent_data.get("defaultOutputModes", ["text"])
         
         # Use provided profile image or default to favicon
-        profile_image_url = form_data.profile_image_url or agent_data.get("profileImageUrl") or "/static/favicon.png"
+        profile_image_url = (
+            form_data.profile_image_url
+            or agent_data.get("profileImageUrl")
+            or "/static/favicon.png"
+        )
         
         # Check if agent with this URL already exists
         existing_agent = Agents.get_agent_by_url(url)
@@ -193,6 +232,7 @@ async def register_agent_by_url(
             default_input_modes=default_input_modes,
             default_output_modes=default_output_modes,
             profile_image_url=profile_image_url,
+            access_control=form_data.access_control,
             user_id=user.id,
         )
         
@@ -203,15 +243,12 @@ async def register_agent_by_url(
             detail=ERROR_MESSAGES.DEFAULT(),
         )
         
-    except requests.exceptions.RequestException as e:
+    except HTTPException:
+        raise
+    except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Error fetching agent's .well-known/agent.json file: {str(e)}",
-        )
-    except ValueError as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid JSON response from agent: {str(e)}",
         )
 
 
@@ -229,25 +266,74 @@ async def fetch_agent_well_known(agent_url: str, user=Depends(get_verified_user)
             detail="Agent URL is required",
         )
 
-    # Ensure the URL has proper scheme
-    if not agent_url.startswith(("http://", "https://")):
-        agent_url = "https://" + agent_url
-
-    # Parse the URL
-    parsed_url = urlparse(agent_url)
-    base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
-    well_known_url = f"{base_url}/.well-known/agent.json"
-
     try:
-        response = requests.get(well_known_url, timeout=10)
-        response.raise_for_status()
-        agent_data = response.json()
-        return agent_data
-    except requests.exceptions.RequestException as e:
+        return fetch_agent_card(normalize_agent_base_url(agent_url))
+    except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Error fetching agent's .well-known/agent.json: {str(e)}",
         )
+
+
+############################
+# GetAgentsAsModels
+############################
+
+
+@router.get("/models")
+async def get_agents_as_models(user=Depends(get_verified_user)):
+    """Get all active agents formatted as models for the chat interface"""
+    agents = (
+        Agents.get_agents()
+        if user.role == "admin"
+        else Agents.get_agents_by_user_id(user.id, permission="read")
+    )
+    return {"data": [_agent_model_payload(agent) for agent in agents]}
+
+
+############################
+# RefreshAgents
+############################
+
+
+@router.post("/refresh", response_model=List[AgentRefreshResult])
+async def refresh_agents(user=Depends(get_admin_user)):
+    """Refresh metadata for all active agents from discovery cards."""
+    return refresh_all_agent_metadata()
+
+
+@router.post("/{agent_id}/refresh", response_model=AgentRefreshResult)
+async def refresh_agent(agent_id: str, user=Depends(get_admin_user)):
+    """Refresh one agent's metadata from its discovery card."""
+    agent = Agents.get_agent_by_id(agent_id)
+    if not agent:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.NOT_FOUND,
+        )
+    return refresh_agent_metadata(agent)
+
+
+############################
+# GetAgentById
+############################
+
+
+@router.get("/{agent_id}", response_model=AgentModel)
+async def get_agent_by_id(agent_id: str, user=Depends(get_verified_user)):
+    """Get a specific agent by ID"""
+    agent = Agents.get_agent_by_id(agent_id)
+    if not agent:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.NOT_FOUND,
+        )
+    if not _can_read_agent(user, agent):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=ERROR_MESSAGES.UNAUTHORIZED,
+        )
+    return agent
 
 
 ############################
@@ -269,8 +355,7 @@ async def update_agent(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    # Check if user has permission (owner or admin)
-    if user.role != "admin" and agent.user_id != user.id:
+    if not _can_write_agent(user, agent):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.UNAUTHORIZED,
@@ -300,8 +385,7 @@ async def delete_agent(agent_id: str, user=Depends(get_verified_user)):
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    # Check if user has permission (owner or admin)
-    if user.role != "admin" and agent.user_id != user.id:
+    if not _can_write_agent(user, agent):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.UNAUTHORIZED,
@@ -334,6 +418,42 @@ async def send_message_to_agent(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Agent not found",
         )
+    if not _can_read_agent(user, agent):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=ERROR_MESSAGES.UNAUTHORIZED,
+        )
+
+    # Build JSON-RPC request following A2A protocol
+    message_id = str(uuid.uuid4())
+    if agent.deployment_mode == "internal":
+        try:
+            reply = await run_agent_turn(
+                provider=agent.provider or "anthropic",
+                model=agent.model
+                or PROVIDER_DEFAULTS.get(agent.provider or "anthropic"),
+                system_prompt=agent.system_prompt or "",
+                user_message=form_data.message,
+            )
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=f"Error communicating with agent: {str(e)}",
+            )
+
+        return {
+            "success": True,
+            "agent_response": {
+                "jsonrpc": "2.0",
+                "result": {
+                    "artifacts": [{"parts": [{"text": reply, "type": "text"}]}]
+                },
+                "id": 1,
+            },
+            "message_id": message_id,
+        }
 
     if not agent.endpoint and not agent.url:
         raise HTTPException(
@@ -343,8 +463,6 @@ async def send_message_to_agent(
 
     endpoint = agent.endpoint or agent.url
 
-    # Build JSON-RPC request following A2A protocol
-    message_id = str(uuid.uuid4())
     jsonrpc_request = {
         "jsonrpc": "2.0",
         "method": "message/send",
@@ -359,8 +477,12 @@ async def send_message_to_agent(
     }
 
     try:
-        # Send request to external agent
-        response = requests.post(endpoint, json=jsonrpc_request, timeout=30)
+        response = post_jsonrpc_to_agent(
+            endpoint,
+            jsonrpc_request,
+            cloud_run_auth_required=agent.cloud_run_auth_required,
+            timeout=30,
+        )
         response.raise_for_status()
 
         response_data = response.json()
@@ -370,53 +492,11 @@ async def send_message_to_agent(
             "message_id": message_id,
         }
 
-    except requests.exceptions.RequestException as e:
+    except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=f"Error communicating with agent: {str(e)}",
         )
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error processing agent response: {str(e)}",
-        )
-
-
-############################
-# GetAgentsAsModels
-############################
-
-
-@router.get("/models")
-async def get_agents_as_models(user=Depends(get_verified_user)):
-    """Get all active agents formatted as models for the chat interface"""
-    agents = Agents.get_agents()
-
-    models = []
-    for agent in agents:
-        model_id = f"agent:{agent.id}"
-        models.append({
-            "id": model_id,
-            "name": agent.name,
-            "object": "model",
-            "created": agent.created_at,
-            "owned_by": "a2a-agent",
-            "agent": {
-                "id": agent.id,
-                "description": agent.description,
-                "endpoint": agent.endpoint or agent.url,
-                "capabilities": agent.capabilities,
-                "skills": agent.skills,
-            },
-            "info": {
-                "meta": {
-                    "description": agent.description,
-                    "capabilities": agent.capabilities,
-                }
-            }
-        })
-
-    return {"data": models}
 
 
 ############################
@@ -484,6 +564,7 @@ async def deploy_agent(
                 model=model,
                 system_prompt=form_data.system_prompt,
                 profile_image_url=form_data.profile_image_url,
+                allow_unauthenticated=form_data.cloud_run_public,
             )
             deployment_mode = "cloud_run"
         except cloud_run_mod.CloudRunDisabled as exc:
@@ -524,6 +605,10 @@ async def deploy_agent(
         model=model,
         deployment_mode=deployment_mode,
         deployment_status="ready",
+        cloud_run_auth_required=(
+            deployment_mode == "cloud_run" and not form_data.cloud_run_public
+        ),
+        access_control=form_data.access_control,
         user_id=user.id,
     )
 
@@ -561,9 +646,13 @@ async def deploy_agent(
 
 @router.get("/{agent_id}/internal-a2a/.well-known/agent.json")
 async def get_internal_agent_card(request: Request, agent_id: str):
-    """A2A discovery card for an internally-hosted agent. Public by A2A spec."""
+    """A2A discovery card for a public internally-hosted agent."""
     agent = Agents.get_agent_by_id(agent_id)
-    if not agent or agent.deployment_mode != "internal":
+    if (
+        not agent
+        or agent.deployment_mode != "internal"
+        or agent.access_control is not None
+    ):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Internal agent not found",
@@ -576,7 +665,7 @@ async def get_internal_agent_card(request: Request, agent_id: str):
 
 @router.post("/{agent_id}/internal-a2a")
 async def internal_agent_jsonrpc(agent_id: str, request: Request):
-    """JSON-RPC handler for an internally-hosted agent. Public by A2A spec."""
+    """JSON-RPC handler for a public internally-hosted agent."""
     try:
         body = await request.json()
     except Exception:
@@ -590,7 +679,11 @@ async def internal_agent_jsonrpc(agent_id: str, request: Request):
     method = body.get("method")
 
     agent = Agents.get_agent_by_id(agent_id)
-    if not agent or agent.deployment_mode != "internal":
+    if (
+        not agent
+        or agent.deployment_mode != "internal"
+        or agent.access_control is not None
+    ):
         return {
             "jsonrpc": "2.0",
             "error": {"code": -32004, "message": "Agent not found"},

--- a/front/backend/open_webui/routers/embed.py
+++ b/front/backend/open_webui/routers/embed.py
@@ -8,6 +8,7 @@ import logging
 
 from open_webui.models.agents import Agents
 from open_webui.constants import ERROR_MESSAGES
+from open_webui.utils.a2a import post_jsonrpc_to_agent
 from starlette.responses import StreamingResponse
 
 router = APIRouter()
@@ -22,7 +23,7 @@ class EmbedAgentResponse(BaseModel):
 @router.get("/agent/{agent_id}", response_model=EmbedAgentResponse)
 async def get_agent_details(agent_id: str):
     agent = Agents.get_agent_by_id(agent_id)
-    if not agent:
+    if not agent or agent.access_control is not None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Agent not found",
@@ -46,7 +47,7 @@ async def get_available_agents():
             profile_image_url=agent.profile_image_url
         )
         for agent in agents
-        if agent.is_active
+        if agent.is_active and agent.access_control is None
     ]
 
 class EmbedChatRequest(BaseModel):
@@ -64,7 +65,7 @@ async def embed_chat_completion(form_data: EmbedChatRequest):
     log.info(f"[EMBED] Chat request for agent: {agent_id}")
         
     agent = Agents.get_agent_by_id(agent_id)
-    if not agent:
+    if not agent or agent.access_control is not None:
         log.error(f"[EMBED] Agent not found: {agent_id}")
         raise HTTPException(status_code=404, detail="Agent not found")
         
@@ -112,7 +113,12 @@ async def embed_chat_completion(form_data: EmbedChatRequest):
     log.debug(f"[EMBED] Request payload: {json.dumps(jsonrpc_request)}")
 
     try:
-        response = requests.post(endpoint, json=jsonrpc_request, timeout=60)
+        response = post_jsonrpc_to_agent(
+            endpoint,
+            jsonrpc_request,
+            cloud_run_auth_required=agent.cloud_run_auth_required,
+            timeout=60,
+        )
         log.info(f"[EMBED] Response status: {response.status_code}")
         
         if not response.ok:

--- a/front/backend/open_webui/routers/openai.py
+++ b/front/backend/open_webui/routers/openai.py
@@ -450,19 +450,26 @@ async def get_all_models(request: Request, user: UserModel) -> dict[str, list]:
         from open_webui.models.agents import Agents
 
         log.info("Adding A2A agents to models list")
-        agents = Agents.get_agents()
+        agents = (
+            Agents.get_agents()
+            if user.role == "admin"
+            else Agents.get_agents_by_user_id(user.id, permission="read")
+        )
 
         for agent in agents:
             agent_model = {
                 "id": f"agent:{agent.id}",
                 "name": agent.name,
-                "owned_by": "a2a",
+                "owned_by": "a2a-agent",
                 "urlIdx": -1,  # Special marker for A2A agents
                 "agent": {
                     "id": agent.id,
                     "name": agent.name,
                     "endpoint": agent.endpoint or agent.url,
                     "description": agent.description or "",
+                    "access_control": agent.access_control,
+                    "user_id": agent.user_id,
+                    "cloud_run_auth_required": agent.cloud_run_auth_required,
                 }
             }
             models["data"].append(agent_model)

--- a/front/backend/open_webui/test/security/test_cloud_run_deploy.py
+++ b/front/backend/open_webui/test/security/test_cloud_run_deploy.py
@@ -169,6 +169,9 @@ class TestCloudRunDeployment(AbstractIntegrationTest):
         body = response.json()
         assert body["endpoint"] == "https://cloudbot.us-west1.run.app"
         assert body["deployment_mode"] == "cloud_run"
+        assert body["cloud_run_auth_required"] is True
+        assert body["access_control"] == {}
+        assert call["kwargs"]["allow_unauthenticated"] is False
 
     @pytest.mark.parametrize(
         "provider, expected_dir, expected_secret_env",
@@ -223,6 +226,22 @@ class TestCloudRunDeployment(AbstractIntegrationTest):
 
         secret_refs = call["kwargs"].get("secret_refs") or {}
         assert "ANTHROPIC_API_KEY" in secret_refs
+
+    def test_cloud_run_public_override_allows_unauthenticated(self, monkeypatch):
+        """Admin may explicitly choose a public Cloud Run agent service."""
+        self._patch_helper(
+            monkeypatch, return_url="https://cloudbot.us-west1.run.app"
+        )
+
+        with mock_current_user_only(_app(), id="root", role="admin"):
+            response = self.fast_api_client.post(
+                self.create_url("/deploy"),
+                json=self._payload(cloud_run_public=True),
+            )
+
+        assert response.status_code == 200, response.text
+        assert self.calls[0]["kwargs"]["allow_unauthenticated"] is True
+        assert response.json()["cloud_run_auth_required"] is False
 
     # -- 4. Failure / rollback ---------------------------------------------
 

--- a/front/backend/open_webui/test/security/test_security_qa.py
+++ b/front/backend/open_webui/test/security/test_security_qa.py
@@ -125,8 +125,11 @@ class TestChatPrivacy(AbstractIntegrationTest):
 
     def test_pending_user_cannot_read_own_chat_list(self):
         """Pending-role user hits any verified endpoint. `get_verified_user` must 401 before the handler runs."""
+        # Trailing slash required: the list route is "/" and create_url strips
+        # slashes, so without this the request hits the SPA catch-all (200)
+        # instead of the gated API route.
         with mock_current_user_only(_app(), id=self.victim_id, role="pending"):
-            response = self.fast_api_client.get(self.create_url("/"))
+            response = self.fast_api_client.get(self.create_url("/") + "/")
         assert response.status_code == 401
 
     def test_pending_user_blocked_from_read_and_create(self):
@@ -230,10 +233,140 @@ class TestAgentDeployAuthz(AbstractIntegrationTest):
                 self.create_url("/deploy"), json=self._payload()
             )
         assert response.status_code == 200, response.text
+        assert response.json()["access_control"] == {}
         assert self._count_agents() == 1
 
 
-# C. Internal A2A surface safety (public endpoints by A2A spec)
+# C. Agent visibility
+
+
+class TestAgentVisibility(AbstractIntegrationTest):
+    """Attacker = another logged-in user. Goal = discover, use, or mutate
+    another user's private agent. Invariant: local agent access_control is
+    enforced consistently across list/read/write/message routes."""
+
+    BASE_PATH = "/api/v1/agents"
+
+    def setup_method(self):
+        super().setup_method()
+        from open_webui.models.agents import Agents
+
+        self.agents = Agents
+        self.owner_id = "alice"
+        self.attacker_id = "bob"
+        self.private_id = "private-agent-001"
+        self.public_id = "public-agent-001"
+
+        Agents.insert_new_agent(
+            id=self.private_id,
+            name="AlicePrivateAgent",
+            description="private",
+            endpoint="https://example.com/private",
+            url="https://example.com/private",
+            access_control={},
+            user_id=self.owner_id,
+        )
+        Agents.insert_new_agent(
+            id=self.public_id,
+            name="PublicAgent",
+            description="public",
+            endpoint="https://example.com/public",
+            url="https://example.com/public",
+            access_control=None,
+            user_id=self.owner_id,
+        )
+
+    def test_list_hides_private_agents_from_other_users(self):
+        """Bob lists agents. Alice's private agent is omitted; public agent remains."""
+        # The collection route is registered at "/" (trailing slash). create_url
+        # strips slashes, so append one here to match how the frontend calls it
+        # ("/api/v1/agents/") instead of falling through to the SPA catch-all.
+        with mock_current_user_only(_app(), id=self.attacker_id, role="user"):
+            response = self.fast_api_client.get(self.create_url("/") + "/")
+
+        assert response.status_code == 200, response.text
+        agent_ids = {agent["id"] for agent in response.json()}
+        assert self.public_id in agent_ids
+        assert self.private_id not in agent_ids
+
+    def test_owner_can_read_private_agent(self):
+        """Alice can still read her own private agent."""
+        with mock_current_user_only(_app(), id=self.owner_id, role="user"):
+            response = self.fast_api_client.get(self.create_url(f"/{self.private_id}"))
+
+        assert response.status_code == 200, response.text
+        assert response.json()["id"] == self.private_id
+
+    def test_other_user_cannot_read_private_agent(self):
+        """Bob cannot fetch Alice's private agent by ID."""
+        with mock_current_user_only(_app(), id=self.attacker_id, role="user"):
+            response = self.fast_api_client.get(self.create_url(f"/{self.private_id}"))
+
+        assert response.status_code == 401
+
+    def test_other_user_cannot_update_private_agent(self):
+        """Bob cannot mutate Alice's private agent."""
+        with mock_current_user_only(_app(), id=self.attacker_id, role="user"):
+            response = self.fast_api_client.patch(
+                self.create_url(f"/{self.private_id}"),
+                json={"name": "HackedAgent"},
+            )
+
+        assert response.status_code == 401
+        fresh = self.agents.get_agent_by_id(self.private_id)
+        assert fresh.name == "AlicePrivateAgent"
+
+    def test_private_internal_message_route_dispatches_in_process(self, monkeypatch):
+        """Authenticated direct message to a private internal agent avoids its hidden A2A URL."""
+        from open_webui.routers import agents as agents_mod
+
+        internal_id = "private-internal-agent-001"
+        self.agents.insert_new_agent(
+            id=internal_id,
+            name="PrivateInternalAgent",
+            description="private internal",
+            endpoint=f"https://hub.example.com/api/v1/agents/{internal_id}/internal-a2a",
+            url=f"https://hub.example.com/api/v1/agents/{internal_id}/internal-a2a",
+            deployment_mode="internal",
+            system_prompt="Answer directly.",
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            access_control={},
+            user_id=self.owner_id,
+        )
+
+        calls = []
+
+        async def fake_run_agent_turn(*, provider, model, system_prompt, user_message):
+            calls.append(
+                {
+                    "provider": provider,
+                    "model": model,
+                    "system_prompt": system_prompt,
+                    "user_message": user_message,
+                }
+            )
+            return "direct reply"
+
+        def fail_external_post(*args, **kwargs):
+            raise AssertionError("private internal agent made an external A2A call")
+
+        monkeypatch.setattr(agents_mod, "run_agent_turn", fake_run_agent_turn)
+        monkeypatch.setattr(agents_mod, "post_jsonrpc_to_agent", fail_external_post)
+
+        with mock_current_user_only(_app(), id=self.owner_id, role="user"):
+            response = self.fast_api_client.post(
+                self.create_url(f"/{internal_id}/message"),
+                json={"message": "hi"},
+            )
+
+        assert response.status_code == 200, response.text
+        assert calls[0]["user_message"] == "hi"
+        artifacts = response.json()["agent_response"]["result"]["artifacts"]
+        assert artifacts[0]["parts"][0]["text"] == "direct reply"
+
+
+# D. Internal A2A surface safety
 
 
 class TestInternalA2ASafety(AbstractIntegrationTest):
@@ -255,6 +388,7 @@ class TestInternalA2ASafety(AbstractIntegrationTest):
                     "system_prompt": self.SECRET_SYSTEM_PROMPT,
                     "provider": "anthropic",
                     "publish_to_registry": False,
+                    "access_control": None,
                 },
             )
         assert response.status_code == 200, response.text
@@ -275,6 +409,48 @@ class TestInternalA2ASafety(AbstractIntegrationTest):
             "GEMINI_API_KEY",
         ):
             assert forbidden not in body, f"leaked: {forbidden}"
+
+    def test_private_internal_a2a_surface_is_hidden(self):
+        """Default-private internal agents must not expose unauthenticated A2A endpoints."""
+        with mock_current_user_only(_app(), id="root", role="admin"):
+            response = self.fast_api_client.post(
+                self.create_url("/deploy"),
+                json={
+                    "name": "PrivateCanaryBot",
+                    "description": "canary",
+                    "system_prompt": self.SECRET_SYSTEM_PROMPT,
+                    "provider": "anthropic",
+                    "publish_to_registry": False,
+                },
+            )
+        assert response.status_code == 200, response.text
+        private_agent_id = response.json()["id"]
+        assert response.json()["access_control"] == {}
+
+        card_response = self.fast_api_client.get(
+            self.create_url(
+                f"/{private_agent_id}/internal-a2a/.well-known/agent.json"
+            )
+        )
+        assert card_response.status_code == 404
+
+        rpc_response = self.fast_api_client.post(
+            self.create_url(f"/{private_agent_id}/internal-a2a"),
+            json={
+                "jsonrpc": "2.0",
+                "method": "message/send",
+                "params": {
+                    "message": {
+                        "messageId": "x",
+                        "role": "user",
+                        "parts": [{"text": "hi", "type": "text"}],
+                    }
+                },
+                "id": 1,
+            },
+        )
+        assert rpc_response.status_code == 200
+        assert "not found" in rpc_response.json()["error"]["message"].lower()
 
     def test_internal_a2a_error_envelope_never_leaks_system_prompt(self):
         """Malformed and valid-but-no-key JSON-RPC both must omit the stored system prompt."""

--- a/front/backend/open_webui/utils/a2a.py
+++ b/front/backend/open_webui/utils/a2a.py
@@ -1,0 +1,92 @@
+"""Helpers for A2A discovery and JSON-RPC calls."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+import requests
+
+
+def normalize_agent_base_url(agent_url: str) -> str:
+    """Normalize an agent URL to a scheme and host base URL."""
+    url = agent_url.strip()
+    if not url.startswith(("http://", "https://")):
+        if "localhost" in url or "127.0.0.1" in url:
+            url = f"http://{url}"
+        else:
+            url = f"https://{url}"
+
+    parsed_url = urlparse(url)
+    return f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+
+def well_known_url_for_agent(agent_url: str, deployment_mode: Optional[str] = None) -> str:
+    """Return the discovery-card URL for an agent."""
+    if deployment_mode == "internal":
+        return f"{agent_url.rstrip('/')}/.well-known/agent.json"
+    return f"{normalize_agent_base_url(agent_url)}/.well-known/agent.json"
+
+
+def cloud_run_audience(endpoint: str) -> str:
+    """Return the Cloud Run service audience for an endpoint URL."""
+    parsed_url = urlparse(endpoint)
+    return f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+
+def authenticated_cloud_run_headers(endpoint: str) -> dict[str, str]:
+    """Build identity-token auth headers for a private Cloud Run service."""
+    from google.auth.transport.requests import Request as GoogleAuthRequest
+    from google.oauth2 import id_token
+
+    token = id_token.fetch_id_token(
+        GoogleAuthRequest(), cloud_run_audience(endpoint)
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def a2a_request_headers(
+    endpoint: str, cloud_run_auth_required: bool = False
+) -> dict[str, str]:
+    """Return HTTP headers for an A2A request."""
+    headers = {"Content-Type": "application/json"}
+    if cloud_run_auth_required:
+        headers.update(authenticated_cloud_run_headers(endpoint))
+    return headers
+
+
+def fetch_agent_card(
+    agent_url: str,
+    *,
+    deployment_mode: Optional[str] = None,
+    cloud_run_auth_required: bool = False,
+    timeout: int = 10,
+) -> dict[str, Any]:
+    """Fetch an A2A discovery card without invoking the agent model."""
+    well_known_url = well_known_url_for_agent(agent_url, deployment_mode)
+    response = requests.get(
+        well_known_url,
+        headers=a2a_request_headers(well_known_url, cloud_run_auth_required),
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def post_jsonrpc_to_agent(
+    endpoint: str,
+    payload: dict[str, Any],
+    *,
+    cloud_run_auth_required: bool = False,
+    timeout: int = 60,
+) -> requests.Response:
+    """Post a JSON-RPC payload to an A2A endpoint."""
+    normalized_endpoint = endpoint.rstrip("/")
+    return requests.post(
+        normalized_endpoint,
+        json=payload,
+        headers=a2a_request_headers(
+            normalized_endpoint, cloud_run_auth_required
+        ),
+        timeout=timeout,
+    )

--- a/front/backend/open_webui/utils/agent_refresh.py
+++ b/front/backend/open_webui/utils/agent_refresh.py
@@ -1,0 +1,99 @@
+"""Agent metadata refresh helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+from open_webui.models.agents import AgentModel, Agents
+from open_webui.utils.a2a import fetch_agent_card
+
+
+log = logging.getLogger(__name__)
+
+
+class AgentRefreshResult(BaseModel):
+    """Result for a single agent metadata refresh."""
+
+    id: str
+    name: Optional[str] = None
+    success: bool
+    error: Optional[str] = None
+
+
+def _metadata_from_card(card: dict[str, Any]) -> dict[str, Any]:
+    metadata = {
+        "name": card.get("name", "Unknown Agent"),
+        "description": card.get("description", ""),
+        "version": card.get("version", "1.0.0"),
+        "capabilities": card.get("capabilities", {}),
+        "skills": card.get("skills", []),
+        "default_input_modes": card.get("defaultInputModes", ["text"]),
+        "default_output_modes": card.get("defaultOutputModes", ["text"]),
+    }
+
+    profile_image_url = (
+        card.get("profileImageUrl")
+        or card.get("profile_image_url")
+        or card.get("image_url")
+    )
+    if profile_image_url:
+        metadata["profile_image_url"] = profile_image_url
+
+    return metadata
+
+
+def refresh_agent_metadata(agent: AgentModel) -> AgentRefreshResult:
+    """Refresh one agent from its A2A discovery card."""
+    if agent.deployment_mode == "internal" and agent.access_control is not None:
+        return AgentRefreshResult(
+            id=agent.id,
+            name=agent.name,
+            success=True,
+        )
+
+    agent_url = agent.endpoint or agent.url
+    if not agent_url:
+        return AgentRefreshResult(
+            id=agent.id,
+            name=agent.name,
+            success=False,
+            error="Agent has no endpoint or URL configured",
+        )
+
+    try:
+        card = fetch_agent_card(
+            agent_url,
+            deployment_mode=agent.deployment_mode,
+            cloud_run_auth_required=agent.cloud_run_auth_required,
+        )
+        updated_agent = Agents.update_agent_metadata_by_id(
+            agent.id, _metadata_from_card(card)
+        )
+        if not updated_agent:
+            return AgentRefreshResult(
+                id=agent.id,
+                name=agent.name,
+                success=False,
+                error="Failed to update agent metadata",
+            )
+        return AgentRefreshResult(
+            id=updated_agent.id,
+            name=updated_agent.name,
+            success=True,
+        )
+    except Exception as exc:
+        log.warning("Failed to refresh agent %s: %s", agent.id, exc)
+        return AgentRefreshResult(
+            id=agent.id,
+            name=agent.name,
+            success=False,
+            error=str(exc),
+        )
+
+
+def refresh_all_agent_metadata() -> list[AgentRefreshResult]:
+    """Refresh metadata for all active agents."""
+    return [refresh_agent_metadata(agent) for agent in Agents.get_agents()]

--- a/front/backend/open_webui/utils/chat.py
+++ b/front/backend/open_webui/utils/chat.py
@@ -43,6 +43,8 @@ from open_webui.models.models import Models
 
 from open_webui.utils.plugin import load_function_module_by_id
 from open_webui.utils.models import get_all_models, check_model_access
+from open_webui.utils.access_control import has_access
+from open_webui.utils.a2a import post_jsonrpc_to_agent
 from open_webui.utils.payload import convert_payload_openai_to_ollama
 from open_webui.utils.response import (
     convert_response_ollama_to_openai,
@@ -158,11 +160,10 @@ async def generate_a2a_agent_chat_completion(
     """Generate chat completion using A2A protocol"""
     log.info("generate_a2a_agent_chat_completion")
 
-    import requests as req
-
     # Extract agent information
     agent_info = model.get("agent", {})
     agent_endpoint = agent_info.get("endpoint")
+    cloud_run_auth_required = agent_info.get("cloud_run_auth_required", False)
 
     if not agent_endpoint:
         raise Exception("Agent endpoint not configured")
@@ -204,7 +205,12 @@ async def generate_a2a_agent_chat_completion(
         # For streaming, we'll make a non-streaming request and stream the response
         # A2A protocol doesn't necessarily support streaming, so we convert
         try:
-            response = req.post(agent_endpoint, json=jsonrpc_request, timeout=60)
+            response = post_jsonrpc_to_agent(
+                agent_endpoint,
+                jsonrpc_request,
+                cloud_run_auth_required=cloud_run_auth_required,
+                timeout=60,
+            )
             response.raise_for_status()
             response_data = response.json()
 
@@ -281,7 +287,12 @@ async def generate_a2a_agent_chat_completion(
     else:
         # Non-streaming response
         try:
-            response = req.post(agent_endpoint, json=jsonrpc_request, timeout=60)
+            response = post_jsonrpc_to_agent(
+                agent_endpoint,
+                jsonrpc_request,
+                cloud_run_auth_required=cloud_run_auth_required,
+                timeout=60,
+            )
             response.raise_for_status()
             response_data = response.json()
 
@@ -472,6 +483,14 @@ async def generate_chat_completion(
             log.error(f"Agent not found in database: {agent_id}")
             raise Exception("Agent not found")
 
+        if not (
+            user.role == "admin"
+            or agent.user_id == user.id
+            or has_access(user.id, "read", agent.access_control)
+        ):
+            log.error("User %s attempted to access hidden agent %s", user.id, agent_id)
+            raise Exception("Agent not found")
+
         log.info(f"Found agent: {agent.name} at {agent.endpoint or agent.url}")
 
         # Internal-mode agents short-circuit the A2A round-trip and call the
@@ -494,6 +513,9 @@ async def generate_chat_completion(
                 "endpoint": agent.endpoint or agent.url,
                 "capabilities": agent.capabilities,
                 "skills": agent.skills,
+                "access_control": agent.access_control,
+                "user_id": agent.user_id,
+                "cloud_run_auth_required": agent.cloud_run_auth_required,
             }
         }
     elif model_id not in models:

--- a/front/backend/open_webui/utils/cloud_run.py
+++ b/front/backend/open_webui/utils/cloud_run.py
@@ -9,6 +9,9 @@ Set ``OPENBEAVS_CLOUD_RUN_DISABLED=1`` on dev/no-creds installs to make
 the router fall back to the existing internal-mode handler instead of
 attempting a real deploy. Without that flag, callers must have
 ``gcloud`` on PATH and a default project configured.
+
+Set ``OPENBEAVS_AGENT_MIN_INSTANCES`` to override the default of one
+warm Cloud Run instance per deployed agent.
 """
 
 from __future__ import annotations
@@ -73,6 +76,15 @@ def _cloud_run_deploy_error_cls():
     return _load_agents_module().CloudRunDeployError
 
 
+def _agent_min_instances() -> int:
+    """Return the configured Cloud Run minimum instance count for agents."""
+    raw_value = os.environ.get("OPENBEAVS_AGENT_MIN_INSTANCES", "1")
+    try:
+        return max(0, int(raw_value))
+    except ValueError:
+        return 1
+
+
 def deploy_provider_agent(
     agent_id: str,
     *,
@@ -123,6 +135,7 @@ def deploy_provider_agent(
         _service_name(agent_id),
         source_dir,
         env_vars,
+        min_instances=_agent_min_instances(),
         secret_refs=secret_refs,
         allow_unauthenticated=True,
     )

--- a/front/backend/open_webui/utils/cloud_run.py
+++ b/front/backend/open_webui/utils/cloud_run.py
@@ -12,6 +12,11 @@ attempting a real deploy. Without that flag, callers must have
 
 Set ``OPENBEAVS_AGENT_MIN_INSTANCES`` to override the default of one
 warm Cloud Run instance per deployed agent.
+
+Dedicated agent services are deployed private by default. Set
+``OPENBEAVS_HUB_SERVICE_ACCOUNT`` when the hub uses a custom Cloud Run
+runtime service account; otherwise the project default compute service
+account is granted ``roles/run.invoker``.
 """
 
 from __future__ import annotations
@@ -85,6 +90,20 @@ def _agent_min_instances() -> int:
         return 1
 
 
+def _hub_invoker_member() -> str | None:
+    configured_member = os.environ.get("OPENBEAVS_HUB_INVOKER_MEMBER")
+    if configured_member:
+        return configured_member
+
+    service_account = os.environ.get("OPENBEAVS_HUB_SERVICE_ACCOUNT")
+    if service_account:
+        if service_account.startswith("serviceAccount:"):
+            return service_account
+        return f"serviceAccount:{service_account}"
+
+    return None
+
+
 def deploy_provider_agent(
     agent_id: str,
     *,
@@ -92,6 +111,7 @@ def deploy_provider_agent(
     model: str,
     system_prompt: str,
     profile_image_url: str | None = None,
+    allow_unauthenticated: bool = False,
 ) -> str:
     """Provision a Cloud Run service for the given internal agent.
 
@@ -130,12 +150,15 @@ def deploy_provider_agent(
         _PROVIDER_SECRET_DEFAULT_NAME[provider],
     )
     secret_refs = {secret_env_name: f"{secret_name}:latest"}
+    hub_invoker_member = _hub_invoker_member()
+    invoker_members = [hub_invoker_member] if hub_invoker_member else None
 
     return deploy_agent_to_cloud_run(
         _service_name(agent_id),
         source_dir,
         env_vars,
         min_instances=_agent_min_instances(),
+        allow_unauthenticated=allow_unauthenticated,
+        invoker_members=invoker_members,
         secret_refs=secret_refs,
-        allow_unauthenticated=True,
     )

--- a/front/backend/open_webui/utils/models.py
+++ b/front/backend/open_webui/utils/models.py
@@ -248,12 +248,16 @@ async def get_all_models(request, user: UserModel = None):
                         "endpoint": agent.endpoint or agent.url,
                         "capabilities": agent.capabilities,
                         "skills": agent.skills,
+                        "access_control": agent.access_control,
+                        "user_id": agent.user_id,
+                        "cloud_run_auth_required": agent.cloud_run_auth_required,
                     },
                     "info": {
                         "meta": {
                             "description": agent.description,
                             "capabilities": agent.capabilities,
                             "profile_image_url": agent.profile_image_url,
+                            "access_control": agent.access_control,
                         }
                     },
                     "tags": [{"name": "agent"}],  # Add AGENT tag
@@ -275,9 +279,19 @@ async def get_all_models(request, user: UserModel = None):
 
 
 def check_model_access(user, model):
-    # A2A agents are always accessible if enabled
     if model.get("owned_by") == "a2a-agent":
-        return True
+        agent = model.get("agent", {})
+        if (
+            user.role == "admin"
+            or agent.get("user_id") == user.id
+            or has_access(
+                user.id,
+                type="read",
+                access_control=agent.get("access_control"),
+            )
+        ):
+            return True
+        raise Exception("Model not found")
 
     if model.get("arena"):
         if not has_access(

--- a/front/cloudbuild.yaml
+++ b/front/cloudbuild.yaml
@@ -32,6 +32,8 @@ steps:
   - '--platform'
   - 'managed'
   - '--allow-unauthenticated'
+  - '--min-instances'
+  - '1'
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/front/deploy-custom.sh
+++ b/front/deploy-custom.sh
@@ -88,6 +88,7 @@ gcloud run deploy "$SERVICE_NAME" \
     --execution-environment="gen2" \
     --memory="8Gi" \
     --cpu="4" \
+    --min-instances=1 \
     --port=8080 \
     --timeout=600 \
     --set-env-vars="HOST=0.0.0.0,WEBUI_PORT=8080,PYTHONUNBUFFERED=1,WEBUI_AUTH=True,DATA_DIR=/tmp,HF_HOME=/tmp/cache,SENTENCE_TRANSFORMERS_HOME=/tmp/cache,ENABLE_RAG_WEB_SEARCH=False,ENABLE_RAG_LOCAL_DOCS=False,HF_HUB_DISABLE_PROGRESS_BARS=1"

--- a/front/src/lib/apis/agents/index.ts
+++ b/front/src/lib/apis/agents/index.ts
@@ -7,8 +7,10 @@ export type DeployAgentForm = {
 	provider?: 'anthropic' | 'openai' | 'gemini';
 	model?: string;
 	profile_image_url?: string;
+	access_control?: null | object;
 	publish_to_registry?: boolean;
 	deploy_to_cloud_run?: boolean;
+	cloud_run_public?: boolean;
 };
 
 export const deployAgent = async (token: string, form: DeployAgentForm) => {

--- a/front/src/lib/components/workspace/Agents.svelte
+++ b/front/src/lib/components/workspace/Agents.svelte
@@ -6,22 +6,48 @@
 	import { WEBUI_BASE_URL } from '$lib/constants';
 
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import AccessControl from '$lib/components/workspace/common/AccessControl.svelte';
 	import Search from '$lib/components/icons/Search.svelte';
 	import Plus from '$lib/components/icons/Plus.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
     import GarbageBin from '$lib/components/icons/GarbageBin.svelte';
 
-	const i18n = getContext('i18n');
+	const i18n = getContext('i18n') as any;
+
+	type AccessControlValue = null | {
+		read?: { group_ids?: string[]; user_ids?: string[] };
+		write?: { group_ids?: string[]; user_ids?: string[] };
+	};
+
+	type AgentItem = {
+		id: string;
+		name: string;
+		description?: string;
+		endpoint?: string;
+		url?: string;
+		profile_image_url?: string;
+		image_url?: string;
+		user_id?: string;
+		access_control?: AccessControlValue;
+		model?: string;
+		foundational_model?: string;
+		deployment_mode?: string;
+		capabilities?: Record<string, unknown>;
+	};
 
 	let loaded = false;
-	let agents = [];
-	let filteredAgents = [];
+	let agents: AgentItem[] = [];
+	let filteredAgents: AgentItem[] = [];
 	let searchValue = '';
 
     let showAddModal = false;
     let addUrl = '';
     let addImageUrl = '';
+    let addAccessControl: AccessControlValue = {};
     let addSubmitting = false;
+    let showAccessModal = false;
+    let selectedAgent: AgentItem | null = null;
+    let editAccessControl: AccessControlValue = {};
 
 	$: if (agents) {
 		filteredAgents = agents.filter(
@@ -29,7 +55,7 @@
 		);
 	}
 
-    const fetchAgents = async () => {
+    const fetchAgents = async (): Promise<void> => {
         try {
             const res = await fetch(`${WEBUI_BASE_URL}/api/v1/agents/`, {
                 headers: { 'Authorization': `Bearer ${localStorage.token}` }
@@ -44,7 +70,7 @@
         }
     };
 
-    const addAgent = async () => {
+    const addAgent = async (): Promise<void> => {
         if (!addUrl || addSubmitting) return;
         addSubmitting = true;
         try {
@@ -56,7 +82,8 @@
                 },
                 body: JSON.stringify({
                     agent_url: addUrl,
-                    profile_image_url: addImageUrl || undefined
+                    profile_image_url: addImageUrl || undefined,
+                    access_control: addAccessControl
                 })
             });
 
@@ -65,6 +92,7 @@
                 showAddModal = false;
                 addUrl = '';
                 addImageUrl = '';
+                addAccessControl = {};
                 models.set(await getModels(localStorage.token));
                 await fetchAgents();
             } else {
@@ -78,7 +106,39 @@
         }
     };
 
-    const deleteAgent = async (id) => {
+    const openAccessModal = (agent: AgentItem): void => {
+        selectedAgent = agent;
+        editAccessControl = agent.access_control === null ? null : (agent.access_control ?? {});
+        showAccessModal = true;
+    };
+
+    const updateAgentAccess = async (): Promise<void> => {
+        if (!selectedAgent) return;
+        try {
+            const res = await fetch(`${WEBUI_BASE_URL}/api/v1/agents/${selectedAgent.id}`, {
+                method: 'PATCH',
+                headers: {
+                    'Authorization': `Bearer ${localStorage.token}`,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ access_control: editAccessControl })
+            });
+            if (res.ok) {
+                toast.success('Visibility updated');
+                models.set(await getModels(localStorage.token));
+                await fetchAgents();
+                showAccessModal = false;
+                selectedAgent = null;
+            } else {
+                const err = await res.json().catch(() => ({}));
+                toast.error(err.detail || 'Failed to update visibility');
+            }
+        } catch (e) {
+            toast.error('Failed to update visibility');
+        }
+    };
+
+    const deleteAgent = async (id: string): Promise<void> => {
         try {
             const res = await fetch(`${WEBUI_BASE_URL}/api/v1/agents/${id}`, {
                 method: 'DELETE',
@@ -136,10 +196,18 @@
                     />
                 </div>
 
+                <div class="mb-4 px-3 py-2 bg-gray-50 dark:bg-gray-950 rounded-lg">
+                    <AccessControl
+                        bind:accessControl={addAccessControl}
+                        accessRoles={['read', 'write']}
+                        allowPublic={true}
+                    />
+                </div>
+
                 <div class="flex justify-end gap-2">
                     <button
                         class="px-4 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
-                        on:click={() => { showAddModal = false; addUrl = ''; addImageUrl = ''; }}
+                        on:click={() => { showAddModal = false; addUrl = ''; addImageUrl = ''; addAccessControl = {}; }}
                     >
                         {$i18n.t('Cancel')}
                     </button>
@@ -149,6 +217,37 @@
                         on:click={addAgent}
                     >
                         {addSubmitting ? $i18n.t('Adding...') : $i18n.t('Add')}
+                    </button>
+                </div>
+            </div>
+        </div>
+    {/if}
+
+    {#if showAccessModal && selectedAgent}
+        <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+            <div class="bg-white dark:bg-gray-900 rounded-2xl p-6 w-full max-w-md shadow-xl">
+                <h2 class="text-xl font-semibold mb-4">{$i18n.t('Visibility')}</h2>
+
+                <div class="mb-4 px-3 py-2 bg-gray-50 dark:bg-gray-950 rounded-lg">
+                    <AccessControl
+                        bind:accessControl={editAccessControl}
+                        accessRoles={['read', 'write']}
+                        allowPublic={true}
+                    />
+                </div>
+
+                <div class="flex justify-end gap-2">
+                    <button
+                        class="px-4 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
+                        on:click={() => { showAccessModal = false; selectedAgent = null; }}
+                    >
+                        {$i18n.t('Cancel')}
+                    </button>
+                    <button
+                        class="px-4 py-2 rounded-lg bg-black dark:bg-white text-white dark:text-black font-medium"
+                        on:click={updateAgentAccess}
+                    >
+                        {$i18n.t('Save')}
                     </button>
                 </div>
             </div>
@@ -209,7 +308,9 @@
 								src={agent.profile_image_url ?? agent.image_url ?? '/static/favicon.png'}
 								alt="agent profile"
 								class=" rounded-full w-full h-auto object-cover"
-                                onError={(e) => e.target.src = '/static/favicon.png'}
+                                on:error={(e) => {
+                                    (e.currentTarget as HTMLImageElement).src = '/static/favicon.png';
+                                }}
 							/>
 						</div>
 					</div>
@@ -221,6 +322,14 @@
                             <!-- Actions -->
                             <div class="flex items-center gap-1">
                                 {#if $user?.role === 'admin' || agent.user_id === $user?.id}
+                                    <Tooltip content={$i18n.t('Visibility')}>
+                                        <button
+                                            class="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-300 transition"
+                                            on:click={() => openAccessModal(agent)}
+                                        >
+                                            <span class="text-xs">{agent.access_control === null ? $i18n.t('Public') : $i18n.t('Private')}</span>
+                                        </button>
+                                    </Tooltip>
                                     <Tooltip content={$i18n.t('Delete')}>
                                         <button
                                             class="p-1.5 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400 transition"

--- a/front/src/routes/(app)/workspace/agents/deploy/+page.svelte
+++ b/front/src/routes/(app)/workspace/agents/deploy/+page.svelte
@@ -10,6 +10,7 @@
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import Textarea from '$lib/components/common/Textarea.svelte';
 	import Checkbox from '$lib/components/common/Checkbox.svelte';
+	import AccessControl from '$lib/components/workspace/common/AccessControl.svelte';
 
 	const i18n = getContext('i18n') as any;
 
@@ -28,8 +29,10 @@
 	let provider: 'anthropic' | 'openai' | 'gemini' = 'anthropic';
 	let model = PROVIDER_DEFAULTS['anthropic'];
 	let profileImageUrl = '';
-	let publishToRegistry = true;
+	let accessControl = {};
+	let publishToRegistry = false;
 	let deployToCloudRun = false;
+	let cloudRunPublic = false;
 
 	let modelTouched = false;
 
@@ -51,8 +54,10 @@
 			provider,
 			model: model || undefined,
 			profile_image_url: profileImageUrl.trim() || undefined,
+			access_control: accessControl,
 			publish_to_registry: publishToRegistry,
-			deploy_to_cloud_run: deployToCloudRun
+			deploy_to_cloud_run: deployToCloudRun,
+			cloud_run_public: cloudRunPublic
 		};
 
 		try {
@@ -164,6 +169,14 @@
 				/>
 			</div>
 
+			<div class="px-3 py-2 bg-gray-50 dark:bg-gray-950 rounded-lg">
+				<AccessControl
+					bind:accessControl
+					accessRoles={['read', 'write']}
+					allowPublic={true}
+				/>
+			</div>
+
 			<label class="flex items-center gap-2 mt-1">
 				<Checkbox
 					state={publishToRegistry ? 'checked' : 'unchecked'}
@@ -175,7 +188,10 @@
 			<label class="flex items-start gap-2">
 				<Checkbox
 					state={deployToCloudRun ? 'checked' : 'unchecked'}
-					on:change={(e) => (deployToCloudRun = e.detail === 'checked')}
+					on:change={(e) => {
+						deployToCloudRun = e.detail === 'checked';
+						if (!deployToCloudRun) cloudRunPublic = false;
+					}}
 				/>
 				<span class="text-sm flex flex-col">
 					<span>{$i18n.t('Deploy to dedicated Cloud Run service (recommended for production)')}</span>
@@ -186,6 +202,16 @@
 					</span>
 				</span>
 			</label>
+
+			{#if deployToCloudRun}
+				<label class="flex items-center gap-2">
+					<Checkbox
+						state={cloudRunPublic ? 'checked' : 'unchecked'}
+						on:change={(e) => (cloudRunPublic = e.detail === 'checked')}
+					/>
+					<span class="text-sm">{$i18n.t('Public Cloud Run endpoint')}</span>
+				</label>
+			{/if}
 
 			<div class="flex justify-end gap-2 mt-2">
 				<button

--- a/tempdoc.txt
+++ b/tempdoc.txt
@@ -1,0 +1,143 @@
+1. Project Arc
+Original problem:
+The original problem was to create a centralized hub for OSU agents and Agentic workflows to live - keeping a single source of truth and everything collected. It should be easy for anyone - researchers, faculty, students - to make a specialized agent for their field. The goal was to build, deploy, and get real users and user feedback on an app that was exactly like this.
+
+Significant milestones:
+OpenWebUI being adopted and hosted live
+Successful E2E test deployed on a .oregonstate.edu website
+First A2A agent test
+Where project is today:
+OpenBeavs is an AI agent hub built for Oregon State University, now in its third and final capstone term (CS 463, Spring 2026). It gives OSU community members a single authenticated workspace to browse, install, and chat with specialized AI agents over Google's A2A (Agent-to-Agent) protocol.
+
+  Functionality delivered:
+
+  Layer: SvelteKit 2 + FastAPI web app
+  Status: Deployed on GCP Cloud Run
+  ────────────────────────────────────────
+  Layer: OSU Microsoft SSO sign-in
+  Status: Partially working — still navigating OSU IT approval pipeline
+  ────────────────────────────────────────
+  Layer: RBAC (Admin / User / Viewer)
+  Status: Delivered via OpenWebUI integration
+  ────────────────────────────────────────
+  Layer: Agent registry / marketplace
+  Status: Working — agents discoverable and installable
+  ────────────────────────────────────────
+  Layer: OSU RAG pipeline (crawls *.oregonstate.edu, Firestore vector store)
+  Status: Functional but incomplete — crawler blocked by self-imposed rate limiting this sprint
+  ────────────────────────────────────────
+  Layer: SQLite → PostgreSQL migration (GCP-hosted)
+  Status: Completed in Winter term
+  ────────────────────────────────────────
+  Layer: CI/CD (GitHub → GCP Cloud Run)
+  Status: In progress
+  ────────────────────────────────────────
+  Layer: Per-user chat encryption + guest session handling
+  Status: In progress (Sprint 11/12)
+  ────────────────────────────────────────
+  Layer: Context-aware agent routing (FR7)
+  Status: In progress
+  ────────────────────────────────────────
+  Layer: Cross-agent conversation context sharing (FR8)
+  Status: In progress
+  ────────────────────────────────────────
+  Layer: Agent deploy-it-yourself view (for developers)
+  Status: In progress
+  ────────────────────────────────────────
+  Layer: Version control / rollback for agents
+  Status: Not started
+  ────────────────────────────────────────
+  Layer: Feedback / issue reporting (FR6)
+  Status: Completed
+  ────────────────────────────────────────
+  Layer: 10,000 concurrent-user scalability
+  Status: Not tested
+
+Deployment state: Live at openbeavs-deploy-test-716080272371.us-west1.run.app. A previous production URL (genesis.dev.oregonstate.edu) was used during stakeholder demos in Winter. This URL needs to be changed to beavsbuild.oregonstate.edu, but waiting on Project Partner to get the new URL to begin switching over.
+
+Known gaps vs. original vision: Full OSU SSO lock-in (the intended security cornerstone) is not yet production-ready. Need to contact UIT in order to scope for all ONID accounts.
+Honest assessment:
+Honestly the biggest change was our delayed work on the timeline. By the middle of the second term (Sprint 7, roughly) we were supposed to be scaling to users and getting real user feedback. What actually ended up happening was that we were just then getting to actually push to live, but were still missing database persistence, a url to live on, and OSU UIT was not helping our ONID SSO. Additionally, the project would have been completed much faster had we not lost a member in the third term and had group members more on board time-commitment wise, as work was not split equally.
+Reflection:
+The outcome expectations were to be getting with users as a New Product. We fell slightly short of that, but ended up with a fully deployed full-stack system that is ready to scale.
+
+2. Narrative Coherence
+Successes:
+Deploying a persistent user and agent registry database
+E2E testing fully deployed, being able to see the app work from a .oregonstate.edu website
+Getting ONID SSO to work for user login
+Challenges:
+Team commitment
+Losing a member in the third term
+Blockers from UIT (domains, ONID SSO)
+
+Patterns
+Lack of work being completed
+Lack of time being put into the project
+Bursts of work being completed at the date end of a sprint
+Lagging behind set dates and timelines
+What changed term-to-term and triggers
+Fall
+NA
+Winter
+Momentum was lost and hard to get back. Commits and merges dropped. The trigger was time away and some de-motivation from the team.
+Spring
+Momentum found its place in between Fall’s high and Winter’s low, setting us at a medium. Additionally, the Project partner got much more involved and started asking for more proof of work, which motivated us to actually develop and work hard.
+
+3. Causal Analysis
+For your most significant successes and challenges, go beyond “what happened” to explain why. Ground your analysis in specific decisions, behaviors, or circumstances. Examples of useful causal frames:
+A technical decision that paid off or created debt later
+A team process that helped (or hurt) velocity over time
+An external constraint (partner availability, scope, tooling) that shaped outcomes
+A moment where the team adapted well (or didn’t) to new information
+4. Technical Growth
+Describe how your team’s technical approach and engineering practices evolved across the three terms. Include:
+Key architecture, tooling, or process decisions and how they held up
+What the team got better at technically (testing, code review, CI/CD, documentation, etc.)
+Any technical debt accumulated, and how much of it was intentional
+What you would do differently from a technical standpoint if starting over
+
+5. Team Dynamics
+Roles evolved from loose shared responsibility into clearer, but mostly informal, ownership. In the first term, the team treated most of the project as collective work: everyone understood the overall goal of building an OSU AI agent hub, but ownership for specific systems was not always explicit. Over time, ownership clarified because the project demanded it. Backend, deployment, frontend integration, documentation, and agent/A2A work naturally separated into different areas of responsibility. This helped the project move forward, but because the shift happened organically instead of through a formal plan, the workload did not always feel evenly distributed.
+
+Communication and coordination worked best when the team had a concrete deliverable in front of it. Examples include getting OpenWebUI deployed, proving A2A communication worked, showing the app on an Oregon State domain, and preparing stakeholder demos. Those targets made it easier to coordinate because the next step was visible and testable. Friction came from vague or dependency-heavy work, especially SSO approval, domain setup, scalability planning, and unfinished sprint tasks. When tasks were not broken into small, owned pieces, progress tended to happen in bursts near sprint deadlines rather than steadily throughout the sprint.
+
+Conflict and disagreement were handled more through adaptation than through formal resolution. The team did not have many major technical arguments, but there was friction around uneven time commitment, delayed work, unclear ownership, and external blockers from OSU UIT. Instead of always addressing those issues directly early on, the team often worked around them: members with more availability or more context picked up urgent tasks so the project could keep moving. That approach was constructive in the short term because it helped us deliver, but it also created pressure later because some accountability problems were not discussed soon enough.
+
+The team learned that collaboration needs visible ownership, regular proof of progress, and earlier escalation of blockers. At the start, we underestimated how much coordination a full-stack deployed product would require, especially with A2A agents, authentication, databases, and Cloud Run deployment all moving at once. By Spring term, we understood that motivation improved when the project partner asked for concrete proof of work and when tasks were tied to demos or working features. If we were starting over, we would define ownership earlier, check progress more frequently, and raise blockers sooner instead of waiting until the end of a sprint.
+
+
+6. Evidence Examples
+
+Artifact 1: front/A2A_IMPLEMENTATION_SUMMARY.md
+This document directly describes the A2A integration inside OpenWebUI. It lists the model registry, agent router, config endpoints, chat-completion routing, and database persistence as the main components of the implementation. It also documents the critical fix that allowed registered agents to appear in the model list. This supports the narrative that the team moved from a general hub idea to a working A2A agent system that users could actually select and chat with.
+
+Artifact 2: cloudbuild.yaml and docs/developAndDeploy.md
+These files show the deployment workflow the team built around Google Cloud Run. cloudbuild.yaml defines the actual steps: pull a cache image, build the unified frontend/backend Docker image, push it to Artifact Registry, and deploy it to the openbeavs-deploy-test Cloud Run service. docs/developAndDeploy.md explains the same process in team-facing language and says that main-branch merges trigger the Cloud Build pipeline. Together, they support the narrative that the project moved from local development toward repeatable deployment.
+
+Artifact 3: front/backend/open_webui/internal/migrations/019_add_agents.py through 023_add_agent_deployment_fields.py
+These migrations show the project becoming more persistent and product-like over time. Migration 019 creates the agent table, migration 020 creates the registry_agent table, migration 021 adds foundational_model, migration 022 adds profile_image_url, and migration 023 adds system prompt, provider, model, deployment mode, and deployment status fields. This reinforces the project arc from a prototype idea toward a real hub where agents can be registered, stored, displayed, and deployed.
+
+Artifact 4: .github/workflows/ci.yml
+The GitHub Actions workflow is a lightweight example of the team's testing and process maturity. It runs Vitest for the frontend and runs Ruff plus pytest for the lightweight prototype backend in back/. It also shows an honest limitation: despite the job name mentioning frontend lint and type checks, the workflow currently only runs the frontend test script, and it does not run the production OpenWebUI backend's broader security/regression tests. This supports the narrative that CI/CD improved, but was still incomplete.
+
+7. Lessons Learned
+James
+
+Lesson 1: Set boundaries early and protect personal reset time.
+For most of this project, I often worked late, handled odd-hour fixes, or did last-minute edits, including work on Sunday nights. Even when the work got done, that pattern made it hard to fully rest or feel at peace outside the project. Going forward, I want to set clearer limits for myself, especially around weekends. At minimum, I want to avoid being responsive after 4 PM on Sundays so I can protect time to reset before the week starts.
+
+Lesson 2: Be upfront when team problems appear.
+Throughout the project, responsibility and workload were not always evenly split. I tried to stay friendly and avoid confrontation, but being nice about the problem did not make it go away or create actionable change. In future group projects or professional settings, I will raise concerns earlier, be more direct about uneven work, and ask for specific changes instead of waiting until the problem becomes normal.
+
+Lesson 3: Ask for more structure from the project partner and do not absorb every gap.
+Our project partner was involved, but the team still had to decide how to break down the work, assign ownership, motivate progress, and turn feature requests into a roadmap. Because of that, I became an informal tech lead while also leading sprints and contributing as a developer. In future projects, I will ask project partners for clearer priorities, acceptance criteria, and decision support earlier. I also want to become more comfortable trusting other people to step up instead of taking every unresolved problem onto my own plate.
+
+Lesson 4: Turn ambiguity into small, testable milestones as early as possible.
+The original idea was broad: build an OSU AI agent hub with authentication, agent discovery, A2A communication, deployment, persistence, and eventually real users. When the goal stayed too broad, it was easy for progress to feel vague until a demo or deadline forced decisions. Going forward, I will break large ideas into visible milestones earlier, with a clear owner and a concrete test for whether each piece works. That would help prevent sprint-end bursts and make progress easier to measure.
+
+Lesson 5: Prioritize a thin end-to-end product slice before expanding scope.
+The moments that mattered most were when we could actually show the system working: OpenWebUI deployed, the app reachable on a live URL, A2A agents registered, and chat flowing through the hub. Some other work, like scalability, advanced routing, and full SSO lock-in, stayed incomplete because the project had many moving parts. In future projects, I would push for the smallest complete user path first, then add depth once the core flow is stable. A working vertical slice creates confidence and makes later decisions easier.
+
+Lesson 6: Document decisions while they are happening, not after the fact.
+By the end of the project, there were many important technical and process decisions to explain: why we used OpenWebUI, how A2A agents became models, how deployment moved to Cloud Run, and why some original goals remained incomplete. Reconstructing that story later is harder than documenting it when the decision is fresh. In future work, I will keep short decision notes, link important PRs or issues, and record why major tradeoffs were made. That will help with handoff, retrospectives, and defending technical choices later.


### PR DESCRIPTION
- Reviewed the cold-start commit (08830ee) and all uncommitted agent
  visibility / access-control work, using `git diff -w` to see past the
  CRLF churn.

- Implemented the next-session work items:
  - Added local agent `access_control` and `cloud_run_auth_required` fields,
    plus an internal migration that makes existing and new local agents private
    by default (`{}`) unless explicitly set public (`null`).
  - Enforced agent visibility across installed-agent listing, model listing,
    OpenAI-compatible model listing, chat dispatch, direct agent messaging,
    update/delete routes, and unauthenticated embed/internal A2A surfaces.
  - Added UI controls for agent visibility when registering by URL, editing an
    installed agent, and deploying a hub-hosted agent.
  - Changed deploy defaults so agents are not published to the marketplace and
    dedicated Cloud Run services are not public unless explicitly requested.
  - Added private Cloud Run invocation support by minting Google identity-token
    request headers for hub-to-agent calls and granting `roles/run.invoker` to
    the configured hub service account (or the default compute service account).
  - Added A2A discovery-card refresh helpers and an hourly in-process
    APScheduler job controlled by `ENABLE_AGENT_REFRESH_SCHEDULER` and
    `AGENT_REFRESH_INTERVAL_MINUTES`.
  - Added admin refresh endpoints for all agents and individual agents.
  - Added focused security regression coverage for private agent visibility,
    private internal A2A endpoints, direct private-internal messaging, and
    Cloud Run public/private deploy flags.

- Validation performed:
  - `python -m py_compile` passed for touched backend modules and security tests.
  - `git diff --check` passed.
  - Full frontend `svelte-check` could not pass in this local environment because
    `@rollup/rollup-win32-x64-msvc` is missing from `node_modules`; the run also
    reports many pre-existing project-wide TypeScript diagnostics.
  - Focused pytest execution could not run because neither the system Python nor
    bundled Python has `pytest` installed.
  - `ruff` could not run because it is not installed locally.
- Planned next work items for the following session:
  - Enforce the intended security/visibility behavior for OpenBeavs.