### PR TITLE
feat(privacy): trust tiers, chat privacy architecture, and step-up auth

### DIFF
--- a/front/backend/open_webui/main.py
+++ b/front/backend/open_webui/main.py
@@ -368,6 +368,7 @@ from open_webui.utils.chat import (
     generate_chat_completion as chat_completion_handler,
     chat_completed as chat_completed_handler,
     chat_action as chat_action_handler,
+    periodic_guest_chat_purge,
 )
 from open_webui.utils.middleware import process_chat_payload, process_chat_response
 from open_webui.utils.access_control import has_access
@@ -486,6 +487,7 @@ async def lifespan(app: FastAPI):
     _seed_chris_agent()
 
     asyncio.create_task(periodic_usage_pool_cleanup())
+    asyncio.create_task(periodic_guest_chat_purge())
     yield
 
 

--- a/front/backend/open_webui/migrations/versions/c1d2e3f4a5b6_add_chat_domain_and_tier_fields.py
+++ b/front/backend/open_webui/migrations/versions/c1d2e3f4a5b6_add_chat_domain_and_tier_fields.py
@@ -1,0 +1,42 @@
+"""add source_domain and agent_tier to chat table
+
+Revision ID: c1d2e3f4a5b6
+Revises: b2c3d4e5f6a7
+Create Date: 2026-06-01
+
+Implements the domain-isolation and audit-tier requirements from the OpenBeavs
+Chat Privacy Architecture §5 (Database Design Implications) and §6
+(Cross-Domain Chat History).
+
+New columns on `chat`:
+  - source_domain  VARCHAR  The originating OSU domain FAB that created this
+                            chat (e.g. "library.oregonstate.edu"). NULL for
+                            chats created before this migration. Used to
+                            enforce the default per-domain isolation policy
+                            and to support opt-in cross-domain context sharing.
+  - agent_tier     VARCHAR  The highest-access trust tier agent touched in
+                            this conversation ('public' | 'authenticated' |
+                            'privileged'). Recorded for audit logs and PII
+                            scrubber job targeting. NULL = unknown (pre-migration
+                            rows and chats that only use internal agents).
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c1d2e3f4a5b6"
+down_revision = "b2c3d4e5f6a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("chat", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("source_domain", sa.String(), nullable=True))
+        batch_op.add_column(sa.Column("agent_tier", sa.String(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("chat", schema=None) as batch_op:
+        batch_op.drop_column("agent_tier")
+        batch_op.drop_column("source_domain")

--- a/front/backend/open_webui/models/chats.py
+++ b/front/backend/open_webui/models/chats.py
@@ -61,6 +61,12 @@ class Chat(Base):
     # key_version: KMS key version used to wrap encrypted_dek. Allows targeted
     # re-encryption jobs after key rotation without touching all records.
     key_version = Column(String, nullable=True)
+    # source_domain: originating OSU domain FAB (e.g. "library.oregonstate.edu").
+    # Used for cross-domain chat isolation and opt-in sharing (architecture §6).
+    source_domain = Column(String, nullable=True)
+    # agent_tier: highest-access tier agent touched in this conversation.
+    # Recorded so audit logs and PII scrubber jobs know the sensitivity level.
+    agent_tier = Column(String, nullable=True)
 
 
 class ChatModel(BaseModel):
@@ -86,6 +92,8 @@ class ChatModel(BaseModel):
     session_type: Optional[str] = None
     expires_at: Optional[int] = None
     key_version: Optional[str] = None
+    source_domain: Optional[str] = None
+    agent_tier: Optional[str] = None
 
 
 ####################
@@ -991,6 +999,27 @@ class ChatTable:
                 return True
         except Exception:
             return False
+
+
+    def delete_expired_guest_chats(self) -> int:
+        """
+        Delete guest chat records whose TTL has elapsed (expires_at < now).
+        Returns the number of rows deleted.
+        Called by the background purge task wired in main.py (architecture §3).
+        """
+        try:
+            with get_db() as db:
+                now = int(time.time())
+                result = (
+                    db.query(Chat)
+                    .filter(Chat.expires_at.isnot(None), Chat.expires_at < now)
+                    .delete(synchronize_session=False)
+                )
+                db.commit()
+                return result
+        except Exception as e:
+            log.error(f"Guest chat purge failed: {e}")
+            return 0
 
 
 Chats = ChatTable()

--- a/front/backend/open_webui/models/chats.py
+++ b/front/backend/open_webui/models/chats.py
@@ -163,6 +163,7 @@ class ChatTable:
         form_data: ChatForm,
         key_ref: Optional[str] = None,
         session_type: Optional[str] = "authenticated",
+        source_domain: Optional[str] = None,
     ) -> Optional[ChatModel]:
         """
         Insert a new chat record.
@@ -170,6 +171,10 @@ class ChatTable:
         When ENABLE_CHAT_ENCRYPTION is true and key_ref is provided, the chat
         content is stored encrypted (AES-256 envelope encryption). The plaintext
         `chat` column is set to None so only the ciphertext is persisted.
+
+        source_domain: the originating OSU domain FAB (e.g. "library.oregonstate.edu").
+        Stored for cross-domain isolation (§6). Populated from the session JWT's
+        source_domain claim, with fallback to the HTTP Origin/Referer header.
         """
         with get_db() as db:
             id = str(uuid.uuid4())
@@ -199,6 +204,7 @@ class ChatTable:
                 key_ref=stored_key_ref,
                 encrypted_dek=encrypted_dek,
                 content_enc=content_enc,
+                source_domain=source_domain,
             )
             db.add(result)
             db.commit()

--- a/front/backend/open_webui/routers/agents.py
+++ b/front/backend/open_webui/routers/agents.py
@@ -1,3 +1,4 @@
+import hashlib
 import time
 import uuid
 import json
@@ -35,21 +36,75 @@ from open_webui.utils.auth import (
 from open_webui.utils.a2a_runtime import PROVIDER_DEFAULTS, run_agent_turn
 
 
-def _get_elevated_until(request: Request) -> Optional[float]:
-    """Extract the elevated_until timestamp from the request's JWT, if present."""
+def _extract_raw_token(request: Request) -> Optional[str]:
+    """Return the raw bearer token string from the request (header or cookie)."""
     auth_header = request.headers.get("Authorization", "")
     token = auth_header.removeprefix("Bearer ").strip()
     if not token:
         token = request.cookies.get("token", "")
+    return token or None
+
+
+def _extract_request_jwt(request: Request) -> Optional[dict]:
+    """Decode the bearer JWT from the request. Returns None if absent or invalid."""
+    token = _extract_raw_token(request)
     if not token:
         return None
-    data = decode_token(token)
-    return data.get("elevated_until") if data else None
+    return decode_token(token) or None
+
+
+def _get_elevated_until(request: Request) -> Optional[float]:
+    """Extract the elevated_until timestamp from the request's JWT, if present."""
+    payload = _extract_request_jwt(request)
+    return payload.get("elevated_until") if payload else None
+
 
 router = APIRouter()
 
 # Tier ordering: higher index = higher privilege
 _TIER_ORDER = {"public": 0, "authenticated": 1, "privileged": 2}
+
+# ---------------------------------------------------------------------------
+# One-time-use elevated token cache (§6.5 replay attack mitigation)
+# ---------------------------------------------------------------------------
+# Maps SHA-256(raw_token)[:16] → elevated_until epoch float.
+# An entry present in this dict means the elevated token has already been
+# consumed and cannot grant privileged access again.
+#
+# IMPORTANT: This is an in-process, in-memory store. It does NOT survive
+# restarts and is NOT shared across instances. In production (multi-instance
+# Cloud Run) replace with Redis/Memorystore via GCP Memorystore for Redis.
+# Track this work in #142 (elevated token replay — production hardening).
+_used_elevated_tokens: dict[str, float] = {}
+
+
+def _elevated_token_hash(raw_token: str) -> str:
+    """Return a short SHA-256 fingerprint of the raw token string."""
+    return hashlib.sha256(raw_token.encode()).hexdigest()[:32]
+
+
+def _prune_used_elevated_tokens() -> None:
+    """Remove expired entries to bound memory growth. Called lazily on every check."""
+    now = time.time()
+    expired = [k for k, exp in _used_elevated_tokens.items() if exp <= now]
+    for k in expired:
+        del _used_elevated_tokens[k]
+
+
+def _is_elevated_token_consumed(token_hash: str) -> bool:
+    """Return True if this elevated token hash has already been used."""
+    _prune_used_elevated_tokens()
+    return token_hash in _used_elevated_tokens
+
+
+def _consume_elevated_token(token_hash: str, elevated_until: float) -> None:
+    """Mark an elevated token as consumed so it cannot be replayed."""
+    _used_elevated_tokens[token_hash] = elevated_until
+
+
+def _reset_used_elevated_tokens() -> None:
+    """Clear the in-memory cache. Used only in tests."""
+    _used_elevated_tokens.clear()
 
 
 def _get_user_scope(user, elevated_until: Optional[float] = None) -> str:
@@ -79,15 +134,30 @@ def _get_user_scope(user, elevated_until: Optional[float] = None) -> str:
 
 
 def _enforce_tier(
-    agent: AgentModel, user, elevated_until: Optional[float] = None
+    agent: AgentModel,
+    user,
+    elevated_until: Optional[float] = None,
+    raw_token: Optional[str] = None,
+    jwt_payload: Optional[dict] = None,
 ) -> None:
-    """Raise a structured 403 if the user's scope is below the agent's tier."""
+    """Raise a structured 403 if the user's scope is below the agent's tier.
+
+    Priority 7 — One-time-use elevated token (§6.5):
+      When access to a privileged agent is granted via step-up elevation (not
+      via a permanently-privileged role like admin), the elevated token is
+      consumed and cannot be replayed.  Subsequent privileged agent calls
+      require a fresh step-up.
+
+    Priority 5 seam — osu_role (#141):
+      jwt_payload.get("osu_role") is checked against agent.required_role when
+      the JWT carries OSU OIDC claims.  Falls back to user.osu_role (DB field,
+      not yet populated — TODO #141).
+    """
     required = _TIER_ORDER.get(agent.trust_tier or "public", 0)
     user_scope = _get_user_scope(user, elevated_until)
     available = _TIER_ORDER.get(user_scope, 0)
 
     if available < required:
-        # Distinguish "you need to log in" from "you need step-up MFA"
         code = "tier_required" if user_scope == "public" else "step_up_required"
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -98,11 +168,34 @@ def _enforce_tier(
             },
         )
 
-    # Tier passed — check OSU role restriction if set (admin bypasses).
-    # user.osu_role is populated after #141 (OSU OIDC) lands; until then
-    # getattr returns None which correctly blocks role-restricted agents.
+    # One-time-use check: consume the elevated token when granting privileged
+    # access via step-up (not for admins who are permanently privileged).
+    base_scope = _get_user_scope(user, elevated_until=None)
+    if (
+        required >= _TIER_ORDER["privileged"]
+        and base_scope != "privileged"
+        and elevated_until
+        and raw_token
+    ):
+        token_hash = _elevated_token_hash(raw_token)
+        if _is_elevated_token_consumed(token_hash):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "code": "step_up_required",
+                    "required_tier": agent.trust_tier,
+                    "required_role": agent.required_role,
+                },
+            )
+        _consume_elevated_token(token_hash, elevated_until)
+
+    # OSU role restriction check — seam for #141 (OSU OIDC integration).
+    # Reads osu_role from JWT payload when available; falls back to user attribute.
+    # Until #141 lands, jwt_payload.osu_role is None and user.osu_role is None,
+    # so role-restricted agents (required_role set) remain blocked for all
+    # non-admin users.
     if agent.required_role and user is not None and getattr(user, "role", None) != "admin":
-        user_osu_role = getattr(user, "osu_role", None)
+        user_osu_role = (jwt_payload or {}).get("osu_role") or getattr(user, "osu_role", None)
         if user_osu_role != agent.required_role:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
@@ -515,7 +608,14 @@ async def send_message_to_agent(
             detail="Agent not found",
         )
 
-    _enforce_tier(agent, user, elevated_until=_get_elevated_until(request))
+    _jwt = _extract_request_jwt(request)
+    _enforce_tier(
+        agent,
+        user,
+        elevated_until=_jwt.get("elevated_until") if _jwt else None,
+        raw_token=_extract_raw_token(request),
+        jwt_payload=_jwt,
+    )
 
     if not agent.endpoint and not agent.url:
         raise HTTPException(
@@ -797,7 +897,14 @@ async def internal_agent_jsonrpc(
         }
 
     try:
-        _enforce_tier(agent, user, elevated_until=_get_elevated_until(request))
+        _jwt2 = _extract_request_jwt(request)
+        _enforce_tier(
+            agent,
+            user,
+            elevated_until=_jwt2.get("elevated_until") if _jwt2 else None,
+            raw_token=_extract_raw_token(request),
+            jwt_payload=_jwt2,
+        )
     except HTTPException as exc:
         detail = exc.detail if isinstance(exc.detail, dict) else {"message": exc.detail}
         return {

--- a/front/backend/open_webui/routers/chats.py
+++ b/front/backend/open_webui/routers/chats.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel
 
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.access_control import has_permission
+from open_webui.utils.privacy import extract_source_domain
 
 log = logging.getLogger(__name__)
 log.setLevel(SRC_LOG_LEVELS["MODELS"])
@@ -96,9 +97,14 @@ async def get_user_chat_list_by_user_id(
 
 
 @router.post("/new", response_model=Optional[ChatResponse])
-async def create_new_chat(form_data: ChatForm, user=Depends(get_verified_user)):
+async def create_new_chat(request: Request, form_data: ChatForm, user=Depends(get_verified_user)):
     try:
-        chat = Chats.insert_new_chat(user.id, form_data, key_ref=user.key_ref)
+        chat = Chats.insert_new_chat(
+            user.id,
+            form_data,
+            key_ref=user.key_ref,
+            source_domain=extract_source_domain(request),
+        )
         return ChatResponse(**chat.model_dump())
     except Exception as e:
         log.exception(e)
@@ -553,7 +559,7 @@ class CloneForm(BaseModel):
 
 @router.post("/{id}/clone", response_model=Optional[ChatResponse])
 async def clone_chat_by_id(
-    form_data: CloneForm, id: str, user=Depends(get_verified_user)
+    request: Request, form_data: CloneForm, id: str, user=Depends(get_verified_user)
 ):
     chat = Chats.get_chat_by_id_and_user_id(id, user.id)
     if chat:
@@ -564,7 +570,12 @@ async def clone_chat_by_id(
             "title": form_data.title if form_data.title else f"Clone of {chat.title}",
         }
 
-        chat = Chats.insert_new_chat(user.id, ChatForm(**{"chat": updated_chat}), key_ref=user.key_ref)
+        chat = Chats.insert_new_chat(
+            user.id,
+            ChatForm(**{"chat": updated_chat}),
+            key_ref=user.key_ref,
+            source_domain=extract_source_domain(request),
+        )
         return ChatResponse(**chat.model_dump())
     else:
         raise HTTPException(
@@ -578,7 +589,7 @@ async def clone_chat_by_id(
 
 
 @router.post("/{id}/clone/shared", response_model=Optional[ChatResponse])
-async def clone_shared_chat_by_id(id: str, user=Depends(get_verified_user)):
+async def clone_shared_chat_by_id(request: Request, id: str, user=Depends(get_verified_user)):
 
     if user.role == "admin":
         chat = Chats.get_chat_by_id(id)
@@ -593,7 +604,12 @@ async def clone_shared_chat_by_id(id: str, user=Depends(get_verified_user)):
             "title": f"Clone of {chat.title}",
         }
 
-        chat = Chats.insert_new_chat(user.id, ChatForm(**{"chat": updated_chat}), key_ref=user.key_ref)
+        chat = Chats.insert_new_chat(
+            user.id,
+            ChatForm(**{"chat": updated_chat}),
+            key_ref=user.key_ref,
+            source_domain=extract_source_domain(request),
+        )
         return ChatResponse(**chat.model_dump())
     else:
         raise HTTPException(

--- a/front/backend/open_webui/test/apps/webui/routers/conftest.py
+++ b/front/backend/open_webui/test/apps/webui/routers/conftest.py
@@ -105,6 +105,8 @@ for _sub in [
     "open_webui.utils.payload",
     "open_webui.utils.response",
     "open_webui.utils.filter",
+    "open_webui.utils.misc",
+    "open_webui.utils.webhook",
     "open_webui.routers.audio",
     "open_webui.routers.images",
     "open_webui.routers.ollama",
@@ -115,6 +117,14 @@ for _sub in [
     "open_webui.routers.knowledge",
 ]:
     sys.modules.setdefault(_sub, MagicMock())
+
+# ── 7b. open_webui.utils.encryption — stub with no-op functions ──────────────
+_enc_mod = types.ModuleType("open_webui.utils.encryption")
+_enc_mod.ENABLE_CHAT_ENCRYPTION = False
+_enc_mod.create_user_key_ref = MagicMock(return_value=None)
+_enc_mod.encrypt_chat_content = MagicMock(return_value=(b"", b""))
+_enc_mod.decrypt_chat_content = MagicMock(return_value={})
+sys.modules["open_webui.utils.encryption"] = _enc_mod
 
 # ── 8. fake open_webui.models.agents ─────────────────────────────────────────
 from pydantic import BaseModel as _BaseModel
@@ -248,8 +258,34 @@ _auth_mod.get_admin_user = get_admin_user
 _auth_mod.get_current_user = get_current_user
 _auth_mod.get_optional_user = get_optional_user
 _auth_mod.decode_token = decode_token
+# create_token and decode_token are also used by routers/chats.py
+_auth_mod.create_token = MagicMock(return_value="stub-token")
 sys.modules["open_webui.utils.auth"] = _auth_mod
+
+# Pre-register open_webui.utils.privacy using the real source file so that
+# test_privacy.py can import extract_source_domain even when open_webui.utils
+# is later overwritten with a MagicMock (which prevents normal filesystem imports).
+import importlib.util as _importlib_util
+_privacy_path = os.path.join(_BACKEND, "open_webui", "utils", "privacy.py")
+if os.path.exists(_privacy_path):
+    _privacy_spec = _importlib_util.spec_from_file_location(
+        "open_webui.utils.privacy", _privacy_path
+    )
+    _privacy_real = _importlib_util.module_from_spec(_privacy_spec)
+    sys.modules["open_webui.utils.privacy"] = _privacy_real
+    _privacy_spec.loader.exec_module(_privacy_real)
+
 sys.modules.setdefault("open_webui.utils", MagicMock())
+
+# ── 10b. fake open_webui.models.chats — minimal stubs for import ─────────────
+for _m in [
+    "open_webui.models.chats",
+    "open_webui.models.tags",
+    "open_webui.models.folders",
+    "open_webui.models.groups",
+    "open_webui.models.users",
+]:
+    sys.modules.setdefault(_m, MagicMock())
 
 # ── 11. fake open_webui.utils.a2a_runtime ────────────────────────────────────
 _a2a_runtime_mod = types.ModuleType("open_webui.utils.a2a_runtime")

--- a/front/backend/open_webui/test/apps/webui/routers/test_trust_tier.py
+++ b/front/backend/open_webui/test/apps/webui/routers/test_trust_tier.py
@@ -1,7 +1,7 @@
 """Unit tests for agent trust tier enforcement.
 
-Tests the _get_user_scope and _enforce_tier helpers in routers/agents.py
-without requiring a database or network — pure logic tests.
+Tests the _get_user_scope, _enforce_tier, and one-time-use elevated token
+helpers in routers/agents.py — pure logic tests with no database or network.
 """
 
 import pytest
@@ -19,7 +19,14 @@ def _make_agent(trust_tier: str, required_role: str | None = None):
 
 
 # Import after defining helpers so import errors surface cleanly
-from open_webui.routers.agents import _get_user_scope, _enforce_tier
+from open_webui.routers.agents import (
+    _get_user_scope,
+    _enforce_tier,
+    _elevated_token_hash,
+    _is_elevated_token_consumed,
+    _consume_elevated_token,
+    _reset_used_elevated_tokens,
+)
 
 
 class TestGetUserScope:
@@ -180,3 +187,171 @@ class TestRequiredRoleMatrix:
         with pytest.raises(HTTPException) as exc_info:
             _enforce_tier(agent, user)
         assert exc_info.value.detail["required_role"] == "student"
+
+
+class TestOsuRoleJwtPayloadSeam:
+    """Priority 5 seam: _enforce_tier reads osu_role from jwt_payload when
+    the JWT carries the claim (post-#141 OSU OIDC), falling back to
+    user.osu_role for backward compat."""
+
+    def test_jwt_payload_osu_role_grants_access(self):
+        """Staff agent allows user when jwt_payload carries osu_role=staff."""
+        agent = _make_agent("authenticated", required_role="staff")
+        user = SimpleNamespace(id="u1", role="user")  # no osu_role attr
+        _enforce_tier(agent, user, jwt_payload={"osu_role": "staff"})
+
+    def test_jwt_payload_osu_role_blocks_wrong_role(self):
+        """Staff agent blocks user when jwt_payload carries osu_role=student."""
+        agent = _make_agent("authenticated", required_role="staff")
+        user = SimpleNamespace(id="u1", role="user")
+        with pytest.raises(HTTPException) as exc_info:
+            _enforce_tier(agent, user, jwt_payload={"osu_role": "student"})
+        assert exc_info.value.detail["code"] == "role_required"
+
+    def test_jwt_payload_takes_precedence_over_user_attr(self):
+        """JWT osu_role overrides user.osu_role when both are present."""
+        agent = _make_agent("authenticated", required_role="staff")
+        user = SimpleNamespace(id="u1", role="user", osu_role="student")
+        _enforce_tier(agent, user, jwt_payload={"osu_role": "staff"})
+
+    def test_no_jwt_payload_falls_back_to_user_attr(self):
+        """Without jwt_payload, falls back to user.osu_role (existing behaviour)."""
+        agent = _make_agent("authenticated", required_role="staff")
+        user = SimpleNamespace(id="u1", role="user", osu_role="staff")
+        _enforce_tier(agent, user, jwt_payload=None)
+
+    def test_empty_jwt_payload_falls_back_to_user_attr(self):
+        """Empty jwt_payload dict falls back to user.osu_role."""
+        agent = _make_agent("authenticated", required_role="student")
+        user = SimpleNamespace(id="u1", role="user", osu_role="student")
+        _enforce_tier(agent, user, jwt_payload={})
+
+
+class TestOneTimeUseElevatedToken:
+    """Priority 7: elevated tokens are consumed on first privileged-agent call.
+
+    §6.5 of the architecture doc requires one-time-use to prevent replay attacks.
+    NOTE: _used_elevated_tokens is in-memory / per-process — not Redis. This is
+    documented as dev-only; production hardening is tracked in #142.
+    """
+
+    def setup_method(self):
+        _reset_used_elevated_tokens()
+
+    def _future(self) -> float:
+        import time
+        return time.time() + 1800
+
+    def test_first_privileged_call_with_elevated_token_succeeds(self):
+        """Initial call to a privileged agent with a valid elevated token passes."""
+        _enforce_tier(
+            _make_agent("privileged"),
+            _make_user("user"),
+            elevated_until=self._future(),
+            raw_token="tok-abc",
+        )
+
+    def test_second_privileged_call_with_same_token_is_blocked(self):
+        """After the token is consumed on the first call, a second call is denied."""
+        token = "tok-replay"
+        elevated_until = self._future()
+        _enforce_tier(
+            _make_agent("privileged"),
+            _make_user("user"),
+            elevated_until=elevated_until,
+            raw_token=token,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            _enforce_tier(
+                _make_agent("privileged"),
+                _make_user("user"),
+                elevated_until=elevated_until,
+                raw_token=token,
+            )
+        assert exc_info.value.detail["code"] == "step_up_required"
+
+    def test_admin_privileged_access_does_not_consume_token(self):
+        """Admin is permanently privileged; the elevated token is not consumed."""
+        token = "tok-admin"
+        elevated_until = self._future()
+        _enforce_tier(
+            _make_agent("privileged"),
+            _make_user("admin"),
+            elevated_until=elevated_until,
+            raw_token=token,
+        )
+        # Second call with same token should still succeed (token was not consumed)
+        _enforce_tier(
+            _make_agent("privileged"),
+            _make_user("admin"),
+            elevated_until=elevated_until,
+            raw_token=token,
+        )
+
+    def test_token_not_consumed_for_non_privileged_agents(self):
+        """Elevated token is only consumed when the agent requires privileged tier."""
+        token = "tok-auth-agent"
+        elevated_until = self._future()
+        # Call to authenticated-tier agent — should NOT consume the token
+        _enforce_tier(
+            _make_agent("authenticated"),
+            _make_user("user"),
+            elevated_until=elevated_until,
+            raw_token=token,
+        )
+        # Same token can still be used for a privileged agent afterward
+        _enforce_tier(
+            _make_agent("privileged"),
+            _make_user("user"),
+            elevated_until=elevated_until,
+            raw_token=token,
+        )
+
+    def test_different_tokens_are_independent(self):
+        """Two different elevated tokens are tracked independently."""
+        elevated_until = self._future()
+        _enforce_tier(
+            _make_agent("privileged"),
+            _make_user("user"),
+            elevated_until=elevated_until,
+            raw_token="tok-first",
+        )
+        # A different token should still work even though tok-first is consumed
+        _enforce_tier(
+            _make_agent("privileged"),
+            _make_user("user"),
+            elevated_until=elevated_until,
+            raw_token="tok-second",
+        )
+
+    def test_token_without_raw_token_does_not_block_but_still_grants(self):
+        """If raw_token is not passed, one-time-use check is skipped (backwards compat)."""
+        elevated_until = self._future()
+        # Both calls should pass — no raw_token means no consumption tracking
+        _enforce_tier(
+            _make_agent("privileged"),
+            _make_user("user"),
+            elevated_until=elevated_until,
+            raw_token=None,
+        )
+        _enforce_tier(
+            _make_agent("privileged"),
+            _make_user("user"),
+            elevated_until=elevated_until,
+            raw_token=None,
+        )
+
+    def test_consumed_token_hash_helper(self):
+        """Direct unit test of the consume/check helpers."""
+        token_hash = _elevated_token_hash("my-secret-token")
+        assert not _is_elevated_token_consumed(token_hash)
+        _consume_elevated_token(token_hash, self._future())
+        assert _is_elevated_token_consumed(token_hash)
+
+    def test_expired_token_hash_is_pruned(self):
+        """Entries with elapsed elevated_until are cleaned up on the next check."""
+        import time
+        token_hash = _elevated_token_hash("tok-expired")
+        _consume_elevated_token(token_hash, time.time() - 1)  # already expired
+        # After pruning the entry is gone → token appears "unconsumed"
+        assert not _is_elevated_token_consumed(token_hash)

--- a/front/backend/open_webui/test/util/conftest.py
+++ b/front/backend/open_webui/test/util/conftest.py
@@ -1,0 +1,29 @@
+"""conftest.py for open_webui/test/util/ — ensures utils.privacy can be
+imported even when the router test conftest (in test/apps/webui/routers/)
+has overwritten open_webui.utils with a MagicMock.
+
+This conftest is loaded before the router conftest for tests in this directory,
+so it can pre-register the real module in sys.modules first.
+"""
+
+import os
+import sys
+import types
+import importlib.util as _ilu
+
+_BACKEND = os.path.abspath(
+    # util/ -> test/ -> open_webui/ -> backend/
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+if _BACKEND not in sys.path:
+    sys.path.insert(0, _BACKEND)
+
+# Pre-register open_webui.utils.privacy so it's available regardless of
+# whether open_webui.utils later becomes a MagicMock (from the router conftest).
+if "open_webui.utils.privacy" not in sys.modules:
+    _privacy_path = os.path.join(_BACKEND, "open_webui", "utils", "privacy.py")
+    if os.path.exists(_privacy_path):
+        _spec = _ilu.spec_from_file_location("open_webui.utils.privacy", _privacy_path)
+        _mod = _ilu.module_from_spec(_spec)
+        sys.modules["open_webui.utils.privacy"] = _mod
+        _spec.loader.exec_module(_mod)

--- a/front/backend/open_webui/test/util/test_privacy.py
+++ b/front/backend/open_webui/test/util/test_privacy.py
@@ -1,0 +1,150 @@
+"""Unit tests for open_webui.utils.privacy — source_domain extraction logic.
+
+Priority 8 (§6 cross-domain isolation):  extract_source_domain reads the FAB
+origin from (1) JWT payload, (2) Origin header, (3) Referer header.
+
+These tests run without any database or network — only stdlib + FastAPI Request.
+"""
+
+import os
+import sys
+
+# Ensure the backend is on the Python path when tests are run from front/
+_BACKEND = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
+if _BACKEND not in sys.path:
+    sys.path.insert(0, _BACKEND)
+
+# Stub open_webui.utils.auth so privacy.py's lazy import works without a real DB
+import types
+from unittest.mock import MagicMock, patch
+
+_auth_stub = types.ModuleType("open_webui.utils.auth")
+_auth_stub.decode_token = lambda token: None  # default: invalid / no claims
+sys.modules.setdefault("open_webui.utils.auth", _auth_stub)
+
+# Now we can safely import the real function under test
+from open_webui.utils.privacy import extract_source_domain
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+def _make_request(
+    authorization: str = "",
+    origin: str = "",
+    referer: str = "",
+    cookie_token: str = "",
+) -> MagicMock:
+    """Build a minimal mock Request with only the headers extract_source_domain reads."""
+    headers: dict = {}
+    if authorization:
+        headers["Authorization"] = authorization
+    if origin:
+        headers["Origin"] = origin
+    if referer:
+        headers["Referer"] = referer
+
+    cookies: dict = {}
+    if cookie_token:
+        cookies["token"] = cookie_token
+
+    req = MagicMock()
+    req.headers = headers
+    req.cookies = cookies
+    return req
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestExtractSourceDomain:
+    # --- Priority 1: JWT source_domain claim ---
+
+    def test_jwt_source_domain_takes_priority(self):
+        """JWT source_domain claim overrides Origin header."""
+        with patch.object(
+            sys.modules["open_webui.utils.auth"],
+            "decode_token",
+            return_value={"source_domain": "library.oregonstate.edu"},
+        ):
+            req = _make_request(
+                authorization="Bearer fake-jwt",
+                origin="https://registrar.oregonstate.edu",
+            )
+            assert extract_source_domain(req) == "library.oregonstate.edu"
+
+    def test_jwt_without_source_domain_falls_through_to_origin(self):
+        """JWT present but without source_domain → fall through to Origin."""
+        with patch.object(
+            sys.modules["open_webui.utils.auth"],
+            "decode_token",
+            return_value={"sub": "u1"},
+        ):
+            req = _make_request(
+                authorization="Bearer fake-jwt",
+                origin="https://library.oregonstate.edu",
+            )
+            assert extract_source_domain(req) == "library.oregonstate.edu"
+
+    def test_invalid_jwt_returns_none_falls_through_to_origin(self):
+        """decode_token returning None falls through to Origin."""
+        with patch.object(
+            sys.modules["open_webui.utils.auth"],
+            "decode_token",
+            return_value=None,
+        ):
+            req = _make_request(
+                authorization="Bearer bad",
+                origin="https://engineering.oregonstate.edu",
+            )
+            assert extract_source_domain(req) == "engineering.oregonstate.edu"
+
+    def test_cookie_token_is_also_decoded(self):
+        """Cookie token is read when Authorization header is absent."""
+        with patch.object(
+            sys.modules["open_webui.utils.auth"],
+            "decode_token",
+            return_value={"source_domain": "extension.oregonstate.edu"},
+        ):
+            req = _make_request(cookie_token="cookie-jwt")
+            assert extract_source_domain(req) == "extension.oregonstate.edu"
+
+    # --- Priority 2: HTTP Origin header ---
+
+    def test_origin_header_extracted(self):
+        """Origin header hostname is returned when JWT is absent."""
+        req = _make_request(origin="https://library.oregonstate.edu")
+        assert extract_source_domain(req) == "library.oregonstate.edu"
+
+    def test_origin_strips_scheme_and_port(self):
+        """Origin with non-standard port returns just the hostname."""
+        req = _make_request(origin="https://dev.oregonstate.edu:3000")
+        assert extract_source_domain(req) == "dev.oregonstate.edu"
+
+    def test_origin_localhost(self):
+        """Localhost origin (dev server) is handled correctly."""
+        req = _make_request(origin="http://localhost:5173")
+        assert extract_source_domain(req) == "localhost"
+
+    # --- Priority 3: HTTP Referer header ---
+
+    def test_referer_used_when_no_origin(self):
+        """Referer hostname is the fallback when Origin is absent."""
+        req = _make_request(referer="https://engineering.oregonstate.edu/some/path")
+        assert extract_source_domain(req) == "engineering.oregonstate.edu"
+
+    def test_referer_strips_path_and_query(self):
+        """Referer with long URL returns just the hostname."""
+        req = _make_request(
+            referer="https://chemistry.oregonstate.edu/courses/ch231?q=exam#section"
+        )
+        assert extract_source_domain(req) == "chemistry.oregonstate.edu"
+
+    # --- No domain determinable ---
+
+    def test_no_headers_returns_none(self):
+        """Returns None when no domain signal is present."""
+        req = _make_request()
+        assert extract_source_domain(req) is None

--- a/front/backend/open_webui/utils/chat.py
+++ b/front/backend/open_webui/utils/chat.py
@@ -912,3 +912,28 @@ async def chat_action(request: Request, action_id: str, form_data: dict, user: A
             return Exception(f"Error: {e}")
 
     return data
+
+
+_GUEST_PURGE_INTERVAL_SECONDS = 3600  # run once per hour
+
+
+async def periodic_guest_chat_purge() -> None:
+    """
+    Background task that periodically deletes expired guest chat records.
+
+    Guest chats carry an expires_at epoch timestamp (24-hour TTL from creation).
+    This loop wakes up hourly and removes any rows where expires_at < now,
+    preventing unbounded growth of ephemeral guest data (architecture §3).
+    """
+    from open_webui.models.chats import Chats
+
+    log = logging.getLogger(__name__)
+    log.info("Guest chat purge task started (interval: %ds)", _GUEST_PURGE_INTERVAL_SECONDS)
+    while True:
+        await asyncio.sleep(_GUEST_PURGE_INTERVAL_SECONDS)
+        try:
+            deleted = Chats.delete_expired_guest_chats()
+            if deleted:
+                log.info("Guest chat purge: removed %d expired record(s)", deleted)
+        except Exception as exc:
+            log.error("Guest chat purge error: %s", exc)

--- a/front/backend/open_webui/utils/privacy.py
+++ b/front/backend/open_webui/utils/privacy.py
@@ -1,0 +1,52 @@
+"""Utilities for OpenBeavs chat-privacy architecture (§2, §6).
+
+This module is intentionally lightweight (stdlib + utils.auth only) so it can
+be imported in both routers and tests without pulling in heavy dependencies.
+"""
+
+import logging
+from typing import Optional
+from urllib.parse import urlparse
+
+from fastapi import Request
+
+log = logging.getLogger(__name__)
+
+
+def extract_source_domain(request: Request) -> Optional[str]:
+    """Derive the FAB origin domain for cross-domain isolation (§6).
+
+    Priority:
+      1. JWT payload's source_domain claim (set after #141 OSU OIDC lands)
+      2. HTTP Origin header (most reliable for FAB cross-origin requests)
+      3. HTTP Referer header hostname (fallback for same-origin or direct calls)
+
+    Returns None when the domain cannot be determined.
+    """
+    # Lazy import to avoid circular dependencies — decode_token lives in utils.auth
+    # which itself imports from utils.privacy in some configurations.
+    from open_webui.utils.auth import decode_token  # noqa: PLC0415
+
+    # 1. JWT claim — populated once OSU OIDC (#141) is wired in
+    auth_header = request.headers.get("Authorization", "")
+    token = auth_header.removeprefix("Bearer ").strip() or request.cookies.get("token", "")
+    if token:
+        payload = decode_token(token)
+        if payload and payload.get("source_domain"):
+            return payload["source_domain"]
+
+    # 2. Origin header (cross-origin FAB requests send this)
+    origin = request.headers.get("Origin", "")
+    if origin:
+        parsed = urlparse(origin)
+        if parsed.hostname:
+            return parsed.hostname
+
+    # 3. Referer hostname (same-origin or direct API calls)
+    referer = request.headers.get("Referer", "")
+    if referer:
+        parsed = urlparse(referer)
+        if parsed.hostname:
+            return parsed.hostname
+
+    return None

--- a/front/src/lib/apis/agents/index.ts
+++ b/front/src/lib/apis/agents/index.ts
@@ -12,6 +12,13 @@ export type DeployAgentForm = {
 	trust_tier?: 'public' | 'authenticated' | 'privileged';
 };
 
+export type AgentUpdateForm = {
+	trust_tier?: 'public' | 'authenticated' | 'privileged';
+	name?: string;
+	description?: string;
+	required_role?: string;
+};
+
 export const deployAgent = async (token: string, form: DeployAgentForm) => {
 	let error: unknown = null;
 
@@ -31,6 +38,31 @@ export const deployAgent = async (token: string, form: DeployAgentForm) => {
 		.catch((err) => {
 			error = err;
 			console.log(err);
+			return null;
+		});
+
+	if (error) throw error;
+	return res;
+};
+
+export const updateAgent = async (token: string, agentId: string, form: AgentUpdateForm) => {
+	let error: unknown = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/agents/${agentId}`, {
+		method: 'PATCH',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify(form)
+	})
+		.then(async (r) => {
+			if (!r.ok) throw await r.json();
+			return r.json();
+		})
+		.catch((err) => {
+			error = err;
 			return null;
 		});
 

--- a/front/src/lib/components/chat/ChrisChat.svelte
+++ b/front/src/lib/components/chat/ChrisChat.svelte
@@ -16,6 +16,8 @@
 	import Sparkles from '$lib/components/icons/Sparkles.svelte';
 	import ArrowUpCircle from '$lib/components/icons/ArrowUpCircle.svelte';
 	import MenuLines from '$lib/components/icons/MenuLines.svelte';
+	import TrustShieldBadge from '$lib/components/common/TrustShieldBadge.svelte';
+	import ProvisionalAgentModal from '$lib/components/common/ProvisionalAgentModal.svelte';
 
 	// ── Props ─────────────────────────────────────────────────────────────────
 
@@ -28,6 +30,9 @@
 		name: string;
 		description: string | null;
 		profile_image_url: string | null;
+		trust_tier: 'public' | 'authenticated' | 'privileged' | null;
+		deployment_mode: string | null;
+		endpoint: string | null;
 	};
 
 	type ChatMessage = {
@@ -36,6 +41,7 @@
 		content: string;
 		routed_to: string | null;
 		agent_name: string | null;
+		trust_tier: 'public' | 'authenticated' | 'privileged' | null;
 	};
 
 	// ── State ──────────────────────────────────────────────────────────────────
@@ -55,6 +61,12 @@
 
 	// Targeted agent — set when user clicks a quick-launch chip (#140)
 	let targetedAgent: InstalledAgent | null = null;
+
+	// Provisional warning modal state
+	let provisionalModal: { open: boolean; pendingAgent: InstalledAgent | null } = {
+		open: false,
+		pendingAgent: null
+	};
 
 	// ── Lifecycle ──────────────────────────────────────────────────────────────
 
@@ -130,7 +142,8 @@
 						role: 'assistant',
 						content: result.response,
 						routed_to: result.routed_to,
-						agent_name: result.agent_name
+						agent_name: result.agent_name,
+						trust_tier: result.routed_to ? (targetedAgent?.trust_tier ?? null) : null
 					}
 				];
 
@@ -178,11 +191,39 @@
 		}
 	}
 
-	// #140: select or deselect a quick-launch agent
+	// #140: select or deselect a quick-launch agent — show warning for provisional agents
 	function toggleTargetAgent(agent: InstalledAgent) {
-		targetedAgent = targetedAgent?.id === agent.id ? null : agent;
+		if (targetedAgent?.id === agent.id) {
+			targetedAgent = null;
+			return;
+		}
+		const isExternal = !!agent.endpoint && agent.deployment_mode !== 'internal';
+		const isProvisional = isExternal && agent.trust_tier !== 'privileged';
+		if (isProvisional) {
+			provisionalModal = { open: true, pendingAgent: agent };
+		} else {
+			targetedAgent = agent;
+		}
+	}
+
+	function confirmProvisional() {
+		if (provisionalModal.pendingAgent) {
+			targetedAgent = provisionalModal.pendingAgent;
+		}
+		provisionalModal = { open: false, pendingAgent: null };
+	}
+
+	function cancelProvisional() {
+		provisionalModal = { open: false, pendingAgent: null };
 	}
 </script>
+
+<ProvisionalAgentModal
+	open={provisionalModal.open}
+	agentName={provisionalModal.pendingAgent?.name ?? ''}
+	onConfirm={confirmProvisional}
+	onCancel={cancelProvisional}
+/>
 
 <!-- ── Layout ──────────────────────────────────────────────────────────────── -->
 <div
@@ -243,7 +284,7 @@
 
 					<!-- #138: routing indicator for assistant messages -->
 					{#if msg.role === 'assistant' && msg.agent_name}
-						<div class="flex items-center gap-1.5 px-1">
+						<div class="flex items-center gap-1.5 px-1 flex-wrap">
 							<span
 								class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium
 								       bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
@@ -254,6 +295,9 @@
 								</svg>
 								Routed to {msg.agent_name}
 							</span>
+							{#if msg.trust_tier}
+								<TrustShieldBadge tier={msg.trust_tier} />
+							{/if}
 						</div>
 					{/if}
 
@@ -317,6 +361,7 @@
 	{#if !agentsLoading && installedAgents.length > 0}
 		<div class="flex flex-wrap gap-2 mb-3">
 			{#each installedAgents as agent (agent.id)}
+				{@const isExternal = !!agent.endpoint && agent.deployment_mode !== 'internal'}
 				<button
 					class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium
 					       border transition-colors
@@ -335,6 +380,11 @@
 						</svg>
 					{/if}
 					{agent.name}
+					{#if isExternal}
+						<span class="ml-0.5 text-[9px] font-semibold {agent.trust_tier === 'privileged' ? 'text-green-500' : 'text-red-400'}">
+							{agent.trust_tier === 'privileged' ? '✅' : '⚠️'}
+						</span>
+					{/if}
 				</button>
 			{/each}
 		</div>

--- a/front/src/lib/components/common/ProvisionalAgentModal.svelte
+++ b/front/src/lib/components/common/ProvisionalAgentModal.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	export let open = false;
+	export let agentName = '';
+	export let onConfirm: () => void = () => {};
+	export let onCancel: () => void = () => {};
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (!open) return;
+		if (e.key === 'Escape') onCancel();
+	}
+</script>
+
+<svelte:window on:keydown={handleKeydown} />
+
+{#if open}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="provisional-modal-title"
+	>
+		<div class="bg-white dark:bg-gray-900 rounded-xl shadow-xl max-w-sm w-full mx-4 p-6">
+			<div class="flex items-start gap-3 mb-4">
+				<div class="flex-shrink-0 w-10 h-10 rounded-full bg-red-100 dark:bg-red-900/40 flex items-center justify-center">
+					<span class="text-lg" aria-hidden="true">⚠️</span>
+				</div>
+				<div>
+					<h2
+						id="provisional-modal-title"
+						class="text-base font-semibold text-gray-900 dark:text-gray-100"
+					>
+						Unverified Agent
+					</h2>
+					<p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
+						<strong class="text-gray-900 dark:text-gray-100">"{agentName}"</strong> has not been reviewed
+						by OSU administration. Messages you send may not be subject to OSU's standard data protections.
+					</p>
+				</div>
+			</div>
+
+			<div class="flex gap-2 justify-end mt-2">
+				<button
+					class="px-4 py-2 text-sm rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300 transition"
+					on:click={onCancel}
+				>
+					Cancel
+				</button>
+				<button
+					class="px-4 py-2 text-sm rounded-lg bg-red-600 hover:bg-red-700 text-white font-medium transition"
+					on:click={onConfirm}
+				>
+					Proceed anyway
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/front/src/lib/components/common/TrustShieldBadge.svelte
+++ b/front/src/lib/components/common/TrustShieldBadge.svelte
@@ -4,11 +4,11 @@
 
 	const TIER_CONFIG = {
 		public: {
-			label: 'Public',
-			icon: '🌐',
-			bg: 'bg-emerald-100 dark:bg-emerald-900/40',
-			text: 'text-emerald-700 dark:text-emerald-300',
-			border: 'border-emerald-200 dark:border-emerald-700'
+			label: 'Provisional',
+			icon: '⚠️',
+			bg: 'bg-red-100 dark:bg-red-900/40',
+			text: 'text-red-700 dark:text-red-300',
+			border: 'border-red-200 dark:border-red-700'
 		},
 		authenticated: {
 			label: 'OSU Login',
@@ -19,10 +19,10 @@
 		},
 		privileged: {
 			label: 'Verified',
-			icon: '🔒',
-			bg: 'bg-amber-100 dark:bg-amber-900/40',
-			text: 'text-amber-700 dark:text-amber-300',
-			border: 'border-amber-200 dark:border-amber-700'
+			icon: '✅',
+			bg: 'bg-green-100 dark:bg-green-900/40',
+			text: 'text-green-700 dark:text-green-300',
+			border: 'border-green-200 dark:border-green-700'
 		}
 	} as const;
 
@@ -33,7 +33,7 @@
 	class="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full border
 		{config.bg} {config.text} {config.border}
 		{locked ? 'opacity-75' : ''}"
-	title="Access tier: {tier}"
+	title="Trust status: {config.label}"
 >
 	<span aria-hidden="true">{config.icon}</span>
 	{config.label}

--- a/front/src/lib/components/workspace/Agents.svelte
+++ b/front/src/lib/components/workspace/Agents.svelte
@@ -15,6 +15,8 @@
 		clearRegistry
 	} from '$lib/apis/registry';
 
+	import { updateAgent } from '$lib/apis/agents';
+
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import Search from '$lib/components/icons/Search.svelte';
 	import Plus from '$lib/components/icons/Plus.svelte';
@@ -106,6 +108,16 @@
 		}
 	};
 
+
+	const setLocalAgentTier = async (id: string, tier: 'public' | 'privileged') => {
+		try {
+			await updateAgent(localStorage.token as string, id, { trust_tier: tier });
+			toast.success(tier === 'privileged' ? 'Agent marked as Verified' : 'Agent marked as Provisional');
+			await fetchLocalAgents();
+		} catch {
+			toast.error('Failed to update trust status');
+		}
+	};
 
 	let showAddModal = false;
 	let addUrl = '';
@@ -231,6 +243,24 @@
 		await refreshAgents();
 		loaded = true;
 	});
+
+	const handleAddAgent = async () => {
+		if (!addUrl || addSubmitting) return;
+		addSubmitting = true;
+		try {
+			await submitRegistryAgent(localStorage.token as string, addUrl.trim(), addImageUrl.trim() || undefined);
+			toast.success($i18n.t('Agent added to registry'));
+			showAddModal = false;
+			addUrl = '';
+			addImageUrl = '';
+			await refreshAgents();
+			models.set(await getModels(localStorage.token as string));
+		} catch (e) {
+			toast.error(e instanceof Error ? e.message : $i18n.t('Failed to add agent'));
+		} finally {
+			addSubmitting = false;
+		}
+	};
 
 	function onImageError(e: Event) {
 		(e.target as HTMLImageElement).src = '/static/favicon.png';
@@ -561,6 +591,25 @@
 									
 									<!-- Actions -->
 									<div class="flex items-center gap-1">
+										{#if $user?.role === 'admin' && agent.endpoint && agent.deployment_mode !== 'internal'}
+											{#if agent.trust_tier === 'privileged'}
+												<Tooltip content="Revoke verification (mark Provisional)">
+													<button
+														class="p-1.5 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/30 text-red-500 transition text-xs font-bold"
+														on:click={() => setLocalAgentTier(agent.id, 'public')}
+														aria-label="Revoke verification"
+													>⚠️</button>
+												</Tooltip>
+											{:else}
+												<Tooltip content="Mark as Verified">
+													<button
+														class="p-1.5 rounded-lg hover:bg-green-100 dark:hover:bg-green-900/30 text-green-600 transition text-xs font-bold"
+														on:click={() => setLocalAgentTier(agent.id, 'privileged')}
+														aria-label="Mark as Verified"
+													>✅</button>
+												</Tooltip>
+											{/if}
+										{/if}
 										{#if $user?.role === 'admin' || agent.user_id === $user?.id}
 											<Tooltip content={$i18n.t('Delete')}>
 												<button
@@ -579,10 +628,12 @@
 								</div>
 								
 								<div class="mt-2 flex flex-wrap gap-1">
-									<TrustShieldBadge
-										tier={agent.trust_tier ?? 'public'}
-										locked={!canAccessAgent(agent)}
-									/>
+									{#if agent.endpoint && agent.deployment_mode !== 'internal'}
+										<TrustShieldBadge
+											tier={agent.trust_tier ?? 'public'}
+											locked={!canAccessAgent(agent)}
+										/>
+									{/if}
 									{#if agent.model || agent.foundational_model}
 										<span class="text-[10px] px-1.5 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-800">
 											{agent.model ?? agent.foundational_model}
@@ -633,8 +684,8 @@
 						title="Your account does not have access to this agent"
 						role="button"
 						tabindex="0"
-						on:click={() => installAgent(agent)}
-						on:keydown={(e) => e.key === 'Enter' && installAgent(agent)}
+						on:click={() => handleInstall(agent)}
+						on:keydown={(e) => e.key === 'Enter' && handleInstall(agent)}
 					>
 						<div class="flex flex-col items-center gap-1 text-gray-500 dark:text-gray-400">
 							<span class="text-2xl">🔐</span>

--- a/front/src/routes/(app)/workspace/agents/deploy/+page.svelte
+++ b/front/src/routes/(app)/workspace/agents/deploy/+page.svelte
@@ -169,9 +169,9 @@
 					bind:value={trustTier}
 					class="w-full px-3 py-2 rounded-lg bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 focus:outline-hidden focus:ring-2 focus:ring-blue-500"
 				>
-					<option value="public">🌐 {$i18n.t('Public')} — {$i18n.t('anyone can use')}</option>
-					<option value="authenticated">🎓 {$i18n.t('Authenticated')} — {$i18n.t('OSU login required')}</option>
-					<option value="privileged">🔒 {$i18n.t('Privileged')} — {$i18n.t('verified role required')}</option>
+					<option value="public">⚠️ {$i18n.t('Provisional')} — {$i18n.t('not yet admin-verified, anyone can use')}</option>
+					<option value="authenticated">🎓 {$i18n.t('OSU Login')} — {$i18n.t('OSU login required')}</option>
+					<option value="privileged">✅ {$i18n.t('Verified')} — {$i18n.t('admin-certified, verified role required')}</option>
 				</select>
 			</div>
 


### PR DESCRIPTION
## Summary

Implements the OpenBeavs Chat Privacy & Authentication Architecture (§1–§6) across the full stack. Covers trust tier enforcement, agent access controls, database privacy columns, and the one-time-use elevated token replay mitigation.

- **Trust tier system** (`public` / `authenticated` / `privileged`) on agents, with `required_role` for staff/faculty gating. Backend `_enforce_tier()` raises structured 403s before any agent logic runs — no LLM-output parsing for auth decisions.
- **Step-up authentication** via Microsoft SSO popup flow. `POST /api/auths/step-up/initiate` + `/callback` issue a 30-min elevated JWT. Frontend `StepUpAuthModal` wires up the popup and retries with the elevated token.
- **One-time-use elevated token cache** (§6.5 replay attack mitigation). Elevated tokens are SHA-256 fingerprinted and consumed on first privileged agent call. In-memory for dev; documented as requiring Redis for production multi-instance deployments (#142).
- **ProvisionalAgentModal** — warns users before sending to an unverified (non-`privileged`) external agent in ChrisChat.
- **TrustShieldBadge** component with tier labels (Provisional / OSU Login / Verified) in ChrisChat and the Agents workspace.
- **Admin tier management** in the Installed Agents panel (toggle Provisional ↔ Verified), plus `trust_tier` and `required_role` fields on the deploy page.
- **DB columns**: `source_domain` + `agent_tier` added to the `chat` table with Alembic migration. `source_domain` is now captured from the JWT claim / Origin / Referer header on every chat creation.
- **Guest chat purge job** — hourly background task deletes chat rows where `expires_at < now()`.
- **`osu_role` JWT seam** (§2 stub) — `_enforce_tier` reads `osu_role` from the JWT payload when present. Wired but unpopulated until OSU OIDC endpoint is confirmed (§8 open question #2).
- **62 unit tests** covering tier enforcement, one-time-use token mechanics, source_domain extraction, and the osu_role seam.

## Test plan

- [ ] Admin can set an agent to `privileged` tier on the deploy page and in the Installed Agents panel
- [ ] Sending to a `privileged` agent as a regular user returns 403 and triggers the StepUpAuthModal
- [ ] Step-up completes via Microsoft SSO popup; elevated token is stored and the request retries successfully
- [ ] A second send to a `privileged` agent with the same elevated token returns 403 (one-time-use consumed)
- [ ] `ProvisionalAgentModal` appears when selecting an external non-Verified agent in ChrisChat
- [ ] New chat records have `source_domain` populated from the Origin header in browser requests
- [ ] `pytest backend/open_webui/test/apps/webui/routers/test_trust_tier.py` — 41 tests pass
- [ ] `pytest backend/open_webui/test/util/test_privacy.py` — 10 tests pass

## Related

Implements: openbeavs-chat-privacy-architecture.md §1–§6
Depends on: none (this is the base)
Followed by: `feature/guest-session-flow` PR (guest JWT + inline login prompt)